### PR TITLE
support for higher order boundary conditions

### DIFF
--- a/src/Operators/Evaluation.jl
+++ b/src/Operators/Evaluation.jl
@@ -38,9 +38,15 @@ rdirichlet(d::IntervalDomainSpace)=Evaluation(d,true)
 lneumann(d::IntervalDomainSpace)=Evaluation(d,false,1)
 rneumann(d::IntervalDomainSpace)=Evaluation(d,true,1)
 
+ldiffbc(d::IntervalDomain,k::Integer) = Evaluation(d,false,k)
+rdiffbc(d::IntervalDomain,k::Integer) = Evaluation(d,true,k)
+ldiffbc(d::IntervalDomainSpace,k::Integer) = Evaluation(d,false,k)
+rdiffbc(d::IntervalDomainSpace,k::Integer) = Evaluation(d,true,k)
+
 
 dirichlet(d::Union(IntervalDomain,IntervalDomainSpace))=[ldirichlet(d),rdirichlet(d)]
 neumann(d::Union(IntervalDomain,IntervalDomainSpace))=[lneumann(d),rneumann(d)]
+diffbcs(d::Union(IntervalDomain,IntervalDomainSpace),k::Integer) = [ldiffbc(d,k),rdiffbc(d,k)]
 
 
 function dirichlet{T<:IntervalDomain}(d::Vector{T})

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -2,7 +2,7 @@ export Operator,Functional,InfiniteOperator
 export bandrange, linsolve, periodic
 export dirichlet, neumann
 export ldirichlet,rdirichlet,lneumann,rneumann
-
+export ldiffbc,rdiffbc,diffbcs
 
 
 

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -24,22 +24,20 @@ end
 function Base.getindex(op::Evaluation{ChebyshevSpace,Bool},k::Range)
     x = op.x
     d = domain(op)
-    
-    if     !x && op.order ==0
-        -(-1.).^k  ##TODO: speed up
-    elseif  x && op.order ==0
-        ones(size(k)[1])
-    elseif !x && op.order ==1
-        (k-1).*(k-1).*(-1.).^k*2/(d.b-d.a) 
-    elseif  x && op.order ==1
-        (k-1).*(k-1)*2/(d.b-d.a) 
-    elseif !x && op.order ==2
-        -(k.-1).^2.*((k.-1).^2.-1)/3.*(-1.).^k*(2/(d.b-d.a))^2
-    elseif  x && op.order ==2
-        (k.-1).^2.*((k.-1).^2.-1)/3*(2/(d.b-d.a))^2  
-    else
-        error("Only zero–second order implemented")
+    p = op.order
+    cst = (2/(d.b-d.a))^p
+
+    if x
+        ret = ones(size(k)[1])
+    elseif !x
+        ret = -(-1.).^k ##TODO: speed up
     end
+
+    for m=0:p-1
+        ret .*= ((k-1).^2-m^2)./(2m+1)
+    end
+
+    return ret*cst
 end
 
 function Base.getindex(op::Evaluation{ChebyshevSpace},k::Range)


### PR DESCRIPTION
This should allow support for higher order boundary conditions by using the values of the higher order derivatives of the Chebyshev polynomials at +-1 and scaled by the domain.
Convenience routines to Evaluation: ldiffbc, rdiffbc, and diffbcs.
