### PR TITLE
WIP: generic number type2

### DIFF
--- a/src/Domains/Circle.jl
+++ b/src/Domains/Circle.jl
@@ -6,9 +6,9 @@ export Circle
 ##  Circle
 
 
-immutable Circle{T<:Number} <: PeriodicDomain
+immutable Circle{T<:Number} <: PeriodicDomain{T}
 	center::T
-	radius::Float64
+	radius::T 	#TODO don't know what the T here was supposed to be
 end
 
 Circle(r)=Circle(0.,r)

--- a/src/Domains/Interval.jl
+++ b/src/Domains/Interval.jl
@@ -6,12 +6,13 @@ export Interval
 
 ## Standard interval
 
-immutable Interval{T<:Number} <: IntervalDomain
+immutable Interval{T<:Number} <: IntervalDomain{T}  #repeat <:Number due to Julia issue #9441
 	a::T
 	b::T
 end
 
 Interval()=Interval(-1.,1.)
+Interval(a::Int,b::Int) = Interval(float64(a),float64(b))   #convenience method
 
 function Interval{T<:Number}(d::Vector{T})
     @assert length(d) >1
@@ -25,12 +26,12 @@ function Interval{T<:Number}(d::Vector{T})
             Interval(d[1],d[2])
         end
     else
-        [Interval(d[1:2]),Interval(d[2:end])]
+        [Interval(d[1:2]),Interval(d[2:end])]   #TODO ensure all Intervals are of the same type
     end
 end
 
 
-
+Base.convert{T<:Number}(::Type{Interval{T}}, d::Interval) = Interval{T}(d.a,d.b)
 Base.convert{D<:Domain}(::Type{D},i::Vector)=Interval(i)
 Interval(a::Number,b::Number) = Interval(promote(a,b)...)
 
@@ -45,12 +46,38 @@ Base.last(d::Interval)=d.b
 ## Map interval
 
 
+#TODO dont know why a union type isn't sufficient to collapse these
+tocanonical{T}(d::Interval{T},x::T)=(d.a + d.b - 2x)/(d.a - d.b)
+tocanonicalD{T}(d::Interval{T},x::T)=2/( d.b- d.a)
+fromcanonical{T}(d::Interval{T},x::T)=(d.a + d.b)/2 + (d.b - d.a)x/2
+fromcanonicalD{T}(d::Interval{T},x::T)=( d.b- d.a) / 2
 
-tocanonical(d::Interval,x)=(d.a + d.b - 2x)/(d.a - d.b)
-tocanonicalD(d::Interval,x)=2/( d.b- d.a)
-fromcanonical(d::Interval,x)=.5*(d.a + d.b) + .5*(d.b - d.a)x
-fromcanonicalD(d::Interval,x)=.5*( d.b- d.a)
+tocanonical{T}(d::Interval{T},x::Array{T})=(d.a + d.b - 2x)/(d.a - d.b)
+tocanonicalD{T}(d::Interval{T},x::Array{T})=2/( d.b- d.a)
+fromcanonical{T}(d::Interval{T},x::Array{T})=(d.a + d.b)/2 + (d.b - d.a)x/2
+fromcanonicalD{T}(d::Interval{T},x::Array{T})=( d.b- d.a) / 2
 
+tocanonical{T}(d::Interval{T},x::Fun)=(d.a + d.b - 2x)/(d.a - d.b)
+tocanonicalD{T}(d::Interval{T},x::Fun)=2/( d.b- d.a)
+fromcanonical{T}(d::Interval{T},x::Fun)=(d.a + d.b)/2 + (d.b - d.a)x/2
+fromcanonicalD{T}(d::Interval{T},x::Fun)=( d.b- d.a) / 2
+
+#possibly a bug prevents me from properly dispatching on x (https://groups.google.com/forum/#!topic/julia-users/_paVdB2wy5k)
+for op in (:tocanonical, :tocanonicalD, :fromcanonical, :fromcanonicalD)
+    @eval begin 
+        function $op{T}(d::Interval{T},x)  
+            if typeof(x) <: Array
+                return $op(d,convert(Array{T,},x))
+            elseif typeof(x) <: Number
+                return $op(d,convert(T,x))
+            elseif typeof(x) <: Fun
+                return $op(d,x)
+            else
+                error("Don't know what to do with type: $(typeof(x))")
+            end
+        end
+    end
+end
 
 
 Base.length(d::Interval) = abs(d.b - d.a)

--- a/src/Domains/Line.jl
+++ b/src/Domains/Line.jl
@@ -8,13 +8,14 @@ export Line, PeriodicLine
 ## Standard interval
 
 
-immutable Line <: IntervalDomain
-    centre::Float64  ##TODO Allow complex
-    angle::Float64
-    α::Float64
-    β::Float64    
+immutable Line{T<:Number} <: IntervalDomain{T}
+    centre::T  ##TODO Allow complex
+    angle::T
+    α::T
+    β::T    
     
-    Line(c,a,α,β)=(@assert c==a==0.; @assert α<0; @assert β<0; new(c,a,α,β))
+    #TODO get this inner constructor working again.
+    #Line(c,a,α,β)= begin @assert c==a==0.; @assert α<0; @assert β<0; new(c,a,α,β) end
 end
 
 

--- a/src/Domains/PeriodicInterval.jl
+++ b/src/Domains/PeriodicInterval.jl
@@ -3,7 +3,7 @@
 export PeriodicInterval
 
 
-immutable PeriodicInterval{T<:Number} <: PeriodicDomain
+immutable PeriodicInterval{T<:Number} <: PeriodicDomain{T}
 	a::T
 	b::T
 end
@@ -14,7 +14,7 @@ PeriodicInterval()=PeriodicInterval(-1.π,1.π)
 Interval(d::PeriodicInterval)=Interval(d.a,d.b)
 PeriodicInterval(d::Interval)=PeriodicInterval(d.a,d.b)
 
-
+Base.convert{T<:Number}(::Type{PeriodicInterval{T}}, d::PeriodicInterval) = PeriodicInterval{T}(d.a,d.b)
 
 function PeriodicInterval{T<:Number}(d::Vector{T})
     @assert length(d) == 2

--- a/src/Domains/Ray.jl
+++ b/src/Domains/Ray.jl
@@ -7,7 +7,7 @@ export Ray
 ## Standard interval
 
 
-immutable Ray <: IntervalDomain
+immutable Ray{T<:Number} <: IntervalDomain{T}
     centre::Float64  
     angle::Float64
     orientation::Bool

--- a/src/Extras/Extras.jl
+++ b/src/Extras/Extras.jl
@@ -3,7 +3,7 @@ include("roots.jl")
 include("sample.jl")
 include("timeevolution.jl")
 include("fftBigFloat.jl")
-
+include("fftGeneric.jl")
 
 
 #

--- a/src/Extras/fftBigFloat.jl
+++ b/src/Extras/fftBigFloat.jl
@@ -1,4 +1,5 @@
-function Base.fft!(data::Vector{BigFloat})
+function fft_pow2!(data::Vector{BigFloat})
+    @assert ispow2(length(data))
     nn=int(length(data)/2)
     bigπ=big(π)
     n=nn << 1
@@ -42,25 +43,27 @@ function Base.fft!(data::Vector{BigFloat})
     return data
 end
 
-function Base.fft(x::Vector{Complex{BigFloat}})
+function fft_pow2(x::Vector{Complex{BigFloat}})
+    @assert ispow2(length(x))
     n=length(x)
     y = Array(BigFloat,2n)
     for i = 1:n
         y[2i-1] = x[i].re
         y[2i] = x[i].im
     end
-    Base.fft!(y)
+    fft_pow2!(y)
     return complex(y[1:2:2n-1],y[2:2:2n])
 end
 Base.fft(x::Vector{BigFloat}) = Base.fft(complex(x)) #TODO: simplify
 
-function Base.ifft(x::Vector{Complex{BigFloat}})
+function ifft_pow2(x::Vector{Complex{BigFloat}})
+    @assert ispow2(length(x))
     n=length(x)
     y = Array(BigFloat,2n)
     for i = 1:n
         y[2i-1] = x[i].re
         y[2i] = -x[i].im
     end
-    Base.fft!(y)
+    fft_pow2!(y)
     x = complex(y[1:2:2n-1],-y[2:2:2n])/n
 end

--- a/src/Extras/fftGeneric.jl
+++ b/src/Extras/fftGeneric.jl
@@ -1,0 +1,150 @@
+function dft!(CS::Vector,x::Vector)
+    N = length(x)
+    warn( "Performing a DFT of size $N")
+    @assert length(CS) == N
+    for k=0:(N-1)
+        for n=0:(N-1)
+            arg = -im*2pi* k*n/N
+            cs = exp(arg)
+            @inbounds CS[k+1] += cs*x[n+1]
+        end
+    end
+end
+
+#=  
+function Base.fft{T<:Number}(data::Vector{T})
+    N = length(data)
+    CS = zeros(T,N)
+    dft!(CS,data)
+    return CS
+end
+=#
+
+function type_of_real{T<:Number}(x::Type{T})
+    if T<:Real
+        return T
+    else
+        return T.parameters[1]
+    end
+end
+
+function fft_pow2{T<:Number}(x::Vector{T})
+
+    N = length(x)
+    @assert ispow2(N)
+
+    if N==1
+        return x
+    end
+
+    Even = fft_pow2(x[1:2:end-1])
+    Odd = fft_pow2(x[2:2:end])
+
+    Tpi = convert(type_of_real(T),pi)
+
+    Twiddle = exp(-2Tpi*im/N * [0:N-1])
+    
+    half1 = Even + Odd .* Twiddle[1:(N/2)]
+    half2 = Even + Odd .* Twiddle[(N/2+1):N]
+    return cat(1,half1,half2)
+end
+
+#julia 0.3v makes it impossible to overrride fft only for all non-fftw-supported number types.
+function fft_gen{T<:Number}(x::Vector{T})
+    #=
+    if 0==length(T.parameters)
+        Tbase = T
+    elseif 1==length(T.parameters)
+        Tbase = T.parameters[1]
+    else
+        error("dunno what to do")
+    end
+    
+    S = promote_type(Complex{Tbase},T) #type of output
+    
+    y = zeros(S,length(x))
+    dft!(y,x)
+    =#
+    N = length(x)
+    if ispow2(N)
+        return fft_pow2(x)
+    end
+
+    #Bluestein's, following http://www.dsprelated.com/dspbooks/mdft/Bluestein_s_FFT_Algorithm.html
+    ks = [0:(N-1)]
+    ns = [-N:(N-1)]
+
+    Tpi = convert(type_of_real(T),pi)
+
+    W = exp(im*2*Tpi/N)
+
+    Wks = W.^(-(ks.^2)/2)
+    xq = x .* Wks
+    wq = W.^((ns.^2)/2)
+
+    #convert arrays-to-be-convolved into a common type
+    S = promote_type(eltype(xq),eltype(wq))
+    xq = convert(Vector{S},xq)
+    wq = convert(Vector{S},wq)
+
+    C = conv(xq,wq)[(N+1):(N+N)]
+
+    return Wks .* C
+end
+
+function ifft_gen{T<:Number}(x::Vector{T})
+    return (1/length(x)) * conj(fft_gen(conj(x)))
+end
+
+function ifft_gen!{T<:Number}(x::Vector{T})
+    y = (1/length(x)) * conj(fft_gen(conj(x)))
+    x[:] = y
+    return x
+end
+
+#can extend Base.conv appropriately, unlike FFT
+function Base.conv{T<:Number}(u::StridedVector{T}, v::StridedVector{T})
+    nu = length(u)
+    nv = length(v)
+    n = nu + nv - 1
+    np2 = nextpow2(n)
+    upad = [u, zeros(T, np2 - nu)]
+    vpad = [v, zeros(T, np2 - nv)]
+
+    Y = fft_gen(upad) .* fft_gen(vpad)
+    y = ifft_gen!(Y)
+    if T<:Real      #TODO This would not handle Dual/ComplexDual numbers correctly
+        y = real(y)
+    end
+
+    return y[1:n]
+end
+
+
+
+function redft00{T<:Number}(x::Vector{T})
+    N = length(x)
+    warn( "Performing a REDFT00 of size $N because the numbertype is $T")
+
+    y = zeros(T,N,)
+
+    if N==1
+        y[1] = x[1]
+        return y
+    end
+
+    for k=0:(N-1)
+        y[k+1] = x[1] + (-1)^k * x[N]
+
+        #will only execute for N>2
+        for j=1:(N-2)
+            y[k+1] += 2*x[j+1] * cos(pi*j*k/(N-1))
+        end
+    end
+    return y
+end 
+
+#= 
+b = [BigFloat(r) for r in rand(4000,)]
+ abs(fft_gen(b) - fft(b))
+=# 

--- a/src/Fun/Domain.jl
+++ b/src/Fun/Domain.jl
@@ -4,7 +4,9 @@ export Domain,tocanonical,fromcanonical,Circle,PeriodicInterval,Interval
 export chebyshevpoints
 
 
-abstract Domain
+abstract Domain{T<:Number}  #type parameter represents what find of numeric representation should be used in... TODO explain
+numbertype{T}(d::Domain{T}) = T
+numbertype(d::Any) = Float64 #TODO, temporarily trying to get tests passing and ensure default previous behavior.
 
 immutable AnyDomain <: Domain
 end
@@ -23,17 +25,42 @@ end
 
 ## Interval Domains
 
-abstract IntervalDomain <: Domain
+abstract IntervalDomain{T} <: Domain{T}
+
 ##TODO: Should fromcanonical be fromcanonical!?
-chebyshevroots(n::Integer)=[cos(π*k) for k=-1.+1/(2n):1/n:-1./(2n)]
-chebyshevpoints(n::Integer)= n==1?[0.]:[cos(1.π*k/(n-1)) for k = n-1:-1:0]
-points(d::IntervalDomain,n::Integer) =  n==1?[fromcanonical(d,0.)]:[fromcanonical(d,cos(1.π*k/(n-1))) for k = n-1:-1:0]
+function chebyshevroots(n::Integer,numbertype::Type)
+    _π = convert(numbertype,π)
+    return [cos(_π*k) for k=-1.+1/(2n):1/n:-1./(2n)]
+end
+
+function chebyshevpoints(n::Integer,numbertype::Type)
+    if n==1
+        return zeros(numbertype,1)
+    else
+        _π = convert(numbertype,π)
+        return [cos(_π*k/(n-1)) for k = n-1:-1:0]
+    end
+end 
+
+chebyshevpoints(n::Integer) = chebyshevpoints(n,Float64)
+chebyshevroots(n::Integer) = chebyshevroots(n,Float64)
+
+function points{T}(d::IntervalDomain{T},n::Integer) 
+    if n==1
+        return [fromcanonical(d,zero(T))]
+    else
+        _π = convert(T,π)
+        return [fromcanonical(d,cos(_π*k/(n-1))) for k = n-1:-1:0]  #TODO, refactor to use chebyshevpoints
+    end
+end
+
 points(d::Vector,n::Integer)=points(Interval(d),n)
 bary(v::Vector{Float64},d::IntervalDomain,x::Float64)=bary(v,tocanonical(d,x))
 
-
+#TODO consider moving these
 Base.first(d::IntervalDomain)=fromcanonical(d,-1.0)
 Base.last(d::IntervalDomain)=fromcanonical(d,1.0)
+
 
 function Base.in(x,d::IntervalDomain)
     y=tocanonical(d,x)
@@ -42,12 +69,12 @@ end
 
 ###### Periodic domains
 
-abstract PeriodicDomain <: Domain
+abstract PeriodicDomain{T} <: Domain{T}
 
-points(d::PeriodicDomain,n::Integer) = fromcanonical(d, fourierpoints(n))
+points{T}(d::PeriodicDomain{T},n::Integer) = fromcanonical(d, fourierpoints(n,T))
 
-
-fourierpoints(n::Integer)= 1.π*[-1.:2/n:1. - 2/n]
+fourierpoints(n::Integer) = fourierpoints(n,Float64)
+fourierpoints(n::Integer,numbertype::Type)= convert(numbertype,π)*[-1.:2/n:1. - 2/n]
 
 
 function Base.in(x,d::PeriodicDomain)

--- a/src/Fun/FunctionSpace.jl
+++ b/src/Fun/FunctionSpace.jl
@@ -5,11 +5,10 @@ export FunctionSpace, domainspace, rangespace, maxspace, minspace,Space
 
 # T tells whether the basis is real (cos/sin) or complex
 # D tells what canonical domain is (Interval/PeriodicInterval)
-abstract FunctionSpace{T,D}
+abstract FunctionSpace{T,D} #TODO should be able to write D<:Domain
 
 typealias RealSpace{D} FunctionSpace{Float64,D}
 typealias ComplexSpace{D} FunctionSpace{Complex{Float64},D}
-
 
 
 domain{T,D<:AnyDomain}(::FunctionSpace{T,D})=AnyDomain()
@@ -29,7 +28,6 @@ end
 
 #TODO: should it default to canonicalspace?
 points(d::FunctionSpace,n)=points(domain(d),n)
-
 
 
 ##Check domain compatibility

--- a/src/LinearAlgebra/ultraspherical.jl
+++ b/src/LinearAlgebra/ultraspherical.jl
@@ -3,13 +3,22 @@ export ultraconversion!,ultraint!
 ## Start of support for UFun
 
 # diff from T -> U
-ultradiff(v::Vector)=length(v)==1.?[0.]:([1:length(v)-1].*v[2:end])
+function ultradiff{T<:Number}(v::Vector{T})
+    #polynomial is p(x) = sum ( v[i] * x^(i-1) )
+    if length(v)==1 
+        return zeros(T,1) 
+    else
+        return [1:length(v)-1].*v[2:end] 
+    end
+end 
 
 #int from U ->T
-ultraint(v::Vector)=[0,v./[1:length(v)]]
+function ultraint{T<:Number}(v::Vector{T})
+    cat(1, zero(T), v./[1:length(v)])
+end
 
 #TODO: what about missing truncation?
-function ultraint!(v::Array{Float64,2})
+function ultraint!{T<:Number}(v::Array{T,2})
     for k=size(v,1):-1:2
         for j=1:size(v,2)
             @inbounds v[k,j] = v[k-1,j]/(k-1)
@@ -23,7 +32,7 @@ function ultraint!(v::Array{Float64,2})
     v
 end
 
-function ultraint!(v::Vector{Float64})
+function ultraint!{T<:Number}(v::Vector{T})
     for k=length(v):-1:2
         @inbounds v[k] = v[k-1]/(k-1)
     end
@@ -33,11 +42,10 @@ function ultraint!(v::Vector{Float64})
     v
 end
 
-
 # Convert from U -> T
-function ultraiconversion(v::Vector{Float64})
+function ultraiconversion{T<:Number}(v::Vector{T})
     n = length(v)
-    w = Array(Float64,n)
+    w = Array(T,n)
         
     if n == 1
         w[1] = v[1]
@@ -60,9 +68,9 @@ end
 
 
 # Convert T -> U
-function ultraconversion(v::Vector{Float64})
+function ultraconversion{T<:Number}(v::Vector{T})
     n = length(v);
-    w = Array(Float64,n);
+    w = Array(T,n);
     
     if n == 1
         w[1] = v[1];
@@ -81,7 +89,7 @@ function ultraconversion(v::Vector{Float64})
     w
 end
 
-function ultraconversion!(v::Vector{Float64})
+function ultraconversion!{T<:Number}(v::Vector{T})
     n = length(v) #number of coefficients
 
     if n == 1
@@ -101,7 +109,7 @@ function ultraconversion!(v::Vector{Float64})
     return v
 end
 
-function ultraconversion!(v::Array{Float64,2})
+function ultraconversion!{T<:Number}(v::Array{T,2})
     n = size(v)[1] #number of coefficients
     m = size(v)[2] #number of funs
 
@@ -127,6 +135,11 @@ function ultraconversion!(v::Array{Float64,2})
     return v
 end
 
-ultraiconversion(v::Vector{Complex{Float64}})=ultraiconversion(real(v)) + ultraiconversion(imag(v))*1.im
-ultraconversion(v::Vector{Complex{Float64}})=ultraconversion(real(v)) + ultraconversion(imag(v))*1.im
+
+#ultraiconversion and ultraconversion are linear, so it is possible to define them on Complex numbers as so
+#ultraiconversion(v::Vector{Complex{Float64}})=ultraiconversion(real(v)) + ultraiconversion(imag(v))*1.im
+#ultraconversion(v::Vector{Complex{Float64}})=ultraconversion(real(v)) + ultraconversion(imag(v))*1.im
+
+#using DualNumbers
+#ultraconversion{T<:Number}(v::Vector{Dual{T}})=dual(ultraconversion(real(v)), ultraconversion(epsilon(v)) )
 

--- a/src/Multivariate/Multivariate.jl
+++ b/src/Multivariate/Multivariate.jl
@@ -29,12 +29,20 @@ Fun(f,S::MultivariateDomain,n...)=Fun(f,Space(S),n...)
 Fun(f,dx::Domain,dy::Domain)=Fun(f,dx*dy)
 Fun(f,dx::Vector,dy::Vector)=Fun(f,Interval(dx),Interval(dx))
 
+
 function Fun(f::Function)
     try
         Fun(f,Interval())
-    catch
-        Fun(f,Interval(),Interval())
+    catch ex #TODO only catch errors for wrong number of arguments
+    	warn("Got $(ex) when assuming 1-arity of $f")
+    	try
+        	Fun(f,Interval(),Interval())
+        catch ex
+        	warn("Got $(ex) when assuming 2-arity of $f")
+        	error("Could not construct function")
+        end
     end
 end
+
 
 coefficients(f::BivariateFun,sp::TensorSpace)=coefficients(f,sp[1],sp[2])


### PR DESCRIPTION
work in progress, not ready for merging

continuing from here: https://github.com/ApproxFun/ApproxFun.jl/pull/71

I have made a mistake in writing `chebyshevtransform` in terms of fft and was hoping for help. As far as I can tell, the `fft_gen` and `ifft_gen` functions are working properly. I wrote `chebyshevtransform` to match https://github.com/chebfun/chebfun/blob/master/@chebtech2/vals2coeffs.m , but I didn't really understand what I was doing.

``` julia
julia> n = 8; r = BigFloat[BigFloat(r) for r in rand(n,)];

julia> maximum( abs(chebyshevtransform(r) - chebyshevtransform(float64(r))) )
9.025352232940452587915806506104435996422000032418633430176793848182664747881608e-02 with 256 bits of precision
```
