### PR TITLE
Left & right multiplication for JacobiWeight

### DIFF
--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -108,7 +108,7 @@ end
 
 ## Default Composition with a Fun, LowRankFun, and TensorFun
 
-Base.getindex(B::BandedOperator,f::Fun) = B*SpaceOperator(Multiplication(f,canonicalspace(rangespace(B))),canonicalspace(rangespace(B)),domainspace(B))
+Base.getindex(B::BandedOperator,f::Fun) = B*Multiplication(domainspace(B),f)
 Base.getindex(B::BandedOperator,f::LowRankFun) = PlusOperator(BandedOperator[f.A[i]*B[f.B[i]] for i=1:rank(f)])
 Base.getindex(B::BandedOperator,f::TensorFun) = B[LowRankFun(f)]
 

--- a/src/Spaces/Singularities/JacobiWeightOperators.jl
+++ b/src/Spaces/Singularities/JacobiWeightOperators.jl
@@ -119,31 +119,45 @@ end
 
 ## Multiplication
 
+#Left multiplication. Here, S is considered the domainspace and we determine rangespace accordingly.
+
 function Multiplication{D<:JacobiWeight,T}(f::Fun{D,T},S::JacobiWeight)
     M=Multiplication(Fun(f.coefficients,space(f).space),S.space)
-    MultiplicationWrapper(
-        f,
-        SpaceOperator(M,S,JacobiWeight(space(f).α+S.α,space(f).β+S.β,rangespace(M)))
-    )
+    rsp=canonicalspace(JacobiWeight(space(f).α+S.α,space(f).β+S.β,rangespace(M)))
+    MultiplicationWrapper(f,SpaceOperator(M,S,rsp))
 end
 
 function Multiplication{D,T}(f::Fun{D,T},S::JacobiWeight)
     M=Multiplication(f,S.space)
-    MultiplicationWrapper(
-        f,
-        SpaceOperator(M,S,JacobiWeight(S.α,S.β,rangespace(M)))
-    )
+    rsp=JacobiWeight(S.α,S.β,rangespace(M))
+    MultiplicationWrapper(f,SpaceOperator(M,S,rsp))
 end
 
 function Multiplication{D<:JacobiWeight,T}(f::Fun{D,T},S::IntervalSpace)
     M=Multiplication(Fun(f.coefficients,space(f).space),S)
-    MultiplicationWrapper(
-        f,
-        SpaceOperator(M,S,JacobiWeight(space(f).α,space(f).β,rangespace(M)))
-    )
+    rsp=JacobiWeight(space(f).α,space(f).β,rangespace(M))
+    MultiplicationWrapper(f,SpaceOperator(M,S,rsp))
 end
 
+#Right multiplication. Here, S is considered the rangespace and we determine domainspace accordingly.
 
+function Multiplication{D<:JacobiWeight,T}(S::JacobiWeight,f::Fun{D,T})
+    M=Multiplication(Fun(f.coefficients,space(f).space),S.space)
+    dsp=canonicalspace(JacobiWeight(S.α-space(f).α,S.β-space(f).β,domain(f)))
+    MultiplicationWrapper(f,SpaceOperator(M,dsp,S))
+end
+
+function Multiplication{D,T}(S::JacobiWeight,f::Fun{D,T})
+    M=Multiplication(f,S.space)
+    dsp=JacobiWeight(S.α,S.β,domain(f))
+    MultiplicationWrapper(f,SpaceOperator(M,dsp,S))
+end
+
+function Multiplication{D<:JacobiWeight,T}(S::IntervalSpace,f::Fun{D,T})
+    M=Multiplication(Fun(f.coefficients,space(f).space),S)
+    dsp=JacobiWeight(-space(f).α,-space(f).β,rangespace(M))
+    MultiplicationWrapper(f,SpaceOperator(M,dsp,S))
+end
 
 ## Conversion
 


### PR DESCRIPTION
The scope of the branch name is much larger than the actual changes:
while I was trying to reform multiplication, I actually found a simpler
way to get right multiplication for the SIE operators in JacobiWeight
space. :) (Tests pass)
