### PR TITLE
CubeHelix colormap for GLPlot

### DIFF
--- a/src/Plot/GLPlot.jl
+++ b/src/Plot/GLPlot.jl
@@ -3,31 +3,36 @@
 
 #export surf
 
-
-colorf(m)="xyz.z>0 ? vec4(.2,.4,0.5+"*string(m)*"*xyz.z,0.98) : vec4(.2,.4-"*string(1.2m)*"*xyz.z,0.5,0.98);"
-
+#
+# This colormap is based on the CubeHelix colormap described in
+# D. A. Green, "A colour scheme for the display of astronomical intensity images," Bull. Astr. Soc. India (2011) 39, 289–295.
+# "This – unlike many currently available schemes – is designed to be monotonically increasing in terms of its perceived brightness."
+#
+colorf(ma,mi) = "vec4(   (xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*"))*( 1.0+(1.0-(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))/2.0*(-0.14861*cos(  6.28*(0.5/3.0+1.0-1.5*(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))  )+1.78277*sin(  6.28*(0.5/3.0+1.0-1.5*(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))  )) )   ,    (xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*"))*( 1.0+(1.0-(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))/2.0*(-0.29227*cos(  6.28*(0.5/3.0+1.0-1.5*(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))  )-0.90649*sin(  6.28*(0.5/3.0+1.0-1.5*(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))  )) )       ,   (xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*"))*( 1.0+(1.0-(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))/2.0*(1.97294*cos(  6.28*(0.5/3.0+1.0-1.5*(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))  )+0.0*sin(  6.28*(0.5/3.0+1.0-1.5*(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")))  )) )    ,0.45 +0.0*(xyz.z-("*string(mi)*"))/(("*string(ma)*")-("*string(mi)*")));"
 
 function glupdatewindow(obj,window)
+    require("GLPlot")
     ModernGL=Main.ModernGL
     GLAbstraction=Main.GLAbstraction
-        
+
      ModernGL.glClear(ModernGL.GL_COLOR_BUFFER_BIT | ModernGL.GL_DEPTH_BUFFER_BIT)
     GLAbstraction.render(obj)
-#    Main.GLFW.SwapBuffers(window.glfwWindow)     
+#    Main.GLFW.SwapBuffers(window.glfwWindow)
     Main.GLFW.PollEvents()
-    yield()    
-    obj,window   
+    yield()
+    obj,window
 end
 
 
 ## Vector routines
 function glsurfupdate(vals::Matrix,obj,window)##obj should be type RenderObject, window should be type Screen
+    require("GLPlot")
     GLAbstraction=Main.GLAbstraction
-    
-    zvalues = obj.uniforms[:z] 
-#    colrs=obj.uniforms[:color]    
+
+    zvalues = obj.uniforms[:z]
+#    colrs=obj.uniforms[:color]
     zvalues[:,:]=float32(vals)
-#    color     = map(colorf,vals)    
+#    color     = map(colorf,vals)
 #    GLAbstraction.update!(zvalues, map(GLAbstraction.Vec1,vals)) # now you can simply update the gpu object, which should be very efficient
 #     GLAbstraction.update!(colrs,color)
 
@@ -35,14 +40,15 @@ function glsurfupdate(vals::Matrix,obj,window)##obj should be type RenderObject,
 end
 
 function glsurf(vals::Matrix)
+    require("GLPlot")
     GLAbstraction=Main.GLAbstraction
     ModernGL=Main.ModernGL
     GLPlot=Main.GLPlot
-    
+
     window = GLPlot.createdisplay(w=1000,h=1000,eyeposition=GLAbstraction.Vec3(1.,1.,1.), lookat=GLAbstraction.Vec3(0.,0.,0.),async=true)
-    m=0.5./maximum(abs(vals))
+    mi,ma=extrema(vals)
     ModernGL.glClearColor(1,1,1,0)
-    obj     = GLPlot.glplot(map(GLAbstraction.Vec1,vals) , primitive=GLPlot.SURFACE(), color=colorf(m))
+    obj     = GLPlot.glplot(map(GLAbstraction.Vec1,vals) , primitive=GLPlot.SURFACE(), color=colorf(ma,mi))
 
 
     glupdatewindow(obj,window)
@@ -50,14 +56,15 @@ end
 
 
 function glsurf(xx::Array,yy::Array,vals::Matrix)
+    require("GLPlot")
     GLAbstraction=Main.GLAbstraction
     ModernGL=Main.ModernGL
     GLPlot=Main.GLPlot
-    
+
     window = GLPlot.createdisplay(w=1000,h=1000,eyeposition=GLAbstraction.Vec3(1.,1.,1.), lookat=GLAbstraction.Vec3(0.,0.,0.),async=true)
-    m=0.5./maximum(abs(vals))  
+    mi,ma=extrema(vals)
     ModernGL.glClearColor(1,1,1,0)
-    obj     = GLPlot.glplot(map(GLAbstraction.Vec1,vals) , xrange=float32(xx),yrange=float32(yy),primitive=GLPlot.SURFACE(), color=colorf(m))
+    obj     = GLPlot.glplot(map(GLAbstraction.Vec1,vals) , xrange=float32(xx),yrange=float32(yy),primitive=GLPlot.SURFACE(), color=colorf(ma,mi))
 
 
     glupdatewindow(obj,window)

--- a/src/Plot/Plot.jl
+++ b/src/Plot/Plot.jl
@@ -182,20 +182,43 @@ function plot(xx::Range,yy::Range,f::MultivariateFun,obj,window)
 end
 
 
-plot(f::MultivariateFun)=surf(points(f,1),points(f,2),real(values(f)))
-plot{S,V,T}(f::TensorFun{S,V,T})=surf(vecpoints(f,1),vecpoints(f,2),real(values(f)))
-plot(f::LowRankFun)=surf(vecpoints(f,1),vecpoints(f,2),real(values(f)))
-plot(f::MultivariateFun,obj,window)=glsurfupdate(real(values(f)),obj,window)
+function plot(f::MultivariateFun)
+    s = size(f)
+    g = pad(f,3s[1]+50,3s[2]+50)
+    surf(points(g,1),points(g,2),real(values(g)))
+end
+function plot{S,V,T}(f::TensorFun{S,V,T})
+    s = size(f)
+    g = pad(f,3s[1]+50,3s[2]+50)
+    surf(vecpoints(g,1),vecpoints(g,2),real(values(g)))
+end
+function plot(f::LowRankFun)
+    s = size(f)
+    g = pad(f,3s[1]+50,3s[2]+50)
+    surf(vecpoints(g,1),vecpoints(g,2),real(values(g)))
+end
+function plot(f::MultivariateFun,obj,window)
+    s = size(f)
+    g = pad(f,3s[1]+50,3s[2]+50)
+    glsurfupdate(real(values(g)),obj,window)
+end
 
-
-plot{S<:IntervalSpace,V<:PeriodicSpace,T}(f::TensorFun{S,V,T})=surf(vecpoints(f,1),vecpoints(f,2),real(values(f)))
+function plot{S<:IntervalSpace,V<:PeriodicSpace,T}(f::TensorFun{S,V,T})
+    s = size(f)
+    g = pad(f,3s[1]+50,3s[2]+50)
+    surf(vecpoints(g,1),vecpoints(g,2),real(values(g)))
+end
 function plot{S<:IntervalSpace,V<:PeriodicSpace}(f::ProductFun{S,V})
-    Px,Py=points(f)
-    vals=real(values(f))
+    s = size(f)
+    g = pad(f,3s[1]+50,3s[2]+50)
+    Px,Py=points(g)
+    vals=real(values(g))
     surf([Px Px[:,1]], [Py Py[:,1]], [vals vals[:,1]])
 end
 function plot{S<:IntervalSpace,V<:PeriodicSpace}(f::ProductFun{S,V},obj,window)
-    vals=real(values(f))
+    s = size(f)
+    g = pad(f,3s[1]+50,3s[2]+50)
+    vals=real(values(g))
     glsurfupdate([vals vals[:,1]],obj,window)
 end
 


### PR DESCRIPTION
This introduces the CubeHelix colormap for GLPlots.

The idea is that the brightness varies in proportion with the colours, so that if plots were printed in black and white they would still be scientifically meaningful, unlike the Jet colormap. The snippet produces the image below. (In the image, the brightness also depends on the camera angle but it varies as you move it around.)

```julia
using ApproxFun
setplotter("GLPlot")
sp1,sp2 = Chebyshev(),Chebyshev();
f(x,y) = besselj(2,20abs(y-x));
G = ProductFun(f,sp1,sp2);
ApproxFun.plot(G)
```
![screen shot 2015-03-19 at 5 17 35 pm](https://cloud.githubusercontent.com/assets/8176037/6736470/f8be22f6-ce5c-11e4-9a22-a76cbdf29afe.png)