### PR TITLE
LowRankReform

### DIFF
--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -10,6 +10,7 @@ Base.real(::Type{UnsetNumber})=UnsetNumber
 Base.real{T<:Real}(::Type{T})=T
 Base.real{T<:Real}(::Type{Complex{T}})=T
 Base.eps{T<:Real}(::Type{Complex{T}})=eps(real(T))
+Base.eps{T<:Real}(z::Complex{T})=eps(abs(z))
 
 dotu(f::Vector{Complex{Float64}},g::Vector{Complex{Float64}})=BLAS.dotu(f,g)
 dotu{N<:Real}(f::Vector{Complex{Float64}},g::Vector{N})=dot(conj(f),g)

--- a/src/Multivariate/LowRankFun.jl
+++ b/src/Multivariate/LowRankFun.jl
@@ -1,60 +1,173 @@
+##
+# LowRankFun represents f(x,y) by r column and row slices stored as Funs.
+##
 
 export LowRankFun
 
-
-
-## LowRankFun
-
-
 type LowRankFun{S<:FunctionSpace,M<:FunctionSpace,T<:Number,V<:Number}<:BivariateFun
-  A::Vector{Fun{S,T}}
-  B::Vector{Fun{M,V}}
+    A::Vector{Fun{S,T}}
+    B::Vector{Fun{M,V}}
 
-  function LowRankFun(A::Vector{Fun{S,T}},B::Vector{Fun{M,V}})
-    @assert length(A) == length(B)
-    @assert length(A) > 0
-    new(A,B)
-  end
+    function LowRankFun(A::Vector{Fun{S,T}},B::Vector{Fun{M,V}})
+        @assert length(A) == length(B)
+        @assert length(A) > 0
+        new(A,B)
+    end
 end
 
-LowRankFun{T,V,S,M}(A::Vector{Fun{S,T}},B::Vector{Fun{M,V}})=LowRankFun{S,M,T,V}(A,B)
+LowRankFun{S,M,T,V}(A::Vector{Fun{S,T}},B::Vector{Fun{M,V}})=LowRankFun{S,M,T,V}(A,B)
 
+Base.rank(f::LowRankFun)=length(f.A)
+Base.size(f::LowRankFun,k::Integer)=k==1?mapreduce(length,max,f.A):mapreduce(length,max,f.B)
+Base.size(f::LowRankFun)=size(f,1),size(f,2)
+Base.eltype{S,M,T,V}(::LowRankFun{S,M,T,V})=promote_type(T,V)
 
-LowRankFun{T<:Number}(A::Array{T})=LowRankFun(A,Interval(),Interval())
-function LowRankFun{T<:Number,S<:FunctionSpace,W<:FunctionSpace}(X::Array{T},dx::S,dy::W)
+## Construction via a Matrix of coefficients
+
+function LowRankFun{S<:FunctionSpace,M<:FunctionSpace,T<:Number}(X::Array{T},dx::S,dy::M)
     U,Σ,V=svd(X)
-    m=max(1,count(s->s>10eps(),Σ))
-
+    m=max(1,count(s->s>10eps(T),Σ))
 
     A=Fun{S,T}[Fun(U[:,k].*sqrt(Σ[k]),dx) for k=1:m]
-    B=Fun{W,T}[Fun(conj(V[:,k]).*sqrt(Σ[k]),dy) for k=1:m]
+    B=Fun{M,T}[Fun(conj(V[:,k]).*sqrt(Σ[k]),dy) for k=1:m]
 
     LowRankFun(A,B)
 end
 
-LowRankFun(f,S::TensorSpace)=LowRankFun(f,S[1],S[2])
-LowRankFun(f,S::TensorSpace,n::Integer)=LowRankFun(f,S[1],S[2],n)
-LowRankFun(f,S::TensorSpace,n::Integer,m::Integer)=LowRankFun(f,S[1],S[2],n,m)
+## Construction in a TensorSpace via a Vector of Funs
 
-## We take the convention that row vector pads down
-# TODO: Vector pads right
-for T in (:Float64,:(Complex{Float64}))
-    @eval begin
-        LowRankFun{S}(X::Vector{Fun{S,$T}},d::TensorSpace)=LowRankFun(X,d[1],d[2])
-        function LowRankFun{S}(X::Vector{Fun{S,$T}},dy::FunctionSpace)
-            m=mapreduce(length,max,X)
-            M=zeros($T,m,length(X))
-            for k=1:length(X)
-                M[1:length(X[k]),k]=X[k].coefficients
-            end
+function LowRankFun{S,T,SV}(X::Vector{Fun{S,T}},d::TensorSpace{SV,T,2})
+    @assert d[1] == space(X[1])
+    LowRankFun(X,d[2])
+end
 
-            LowRankFun(M,space(X[1]),dy)
+function LowRankFun{S,T}(X::Vector{Fun{S,T}},dy::FunctionSpace)
+    m=mapreduce(length,max,X)
+    M=zeros(T,m,length(X))
+    for k=1:length(X)
+        M[1:length(X[k]),k]=X[k].coefficients
+    end
+
+    LowRankFun(M,space(X[1]),dy)
+end
+
+## Adaptive constructor selector
+
+function LowRankFun(f::Function,dx::FunctionSpace,dy::FunctionSpace;method::Symbol=:standard,gridx::Integer=64,gridy::Integer=64,maxrank::Integer=100)
+    if method == :standard
+        standardLowRankFun(f,dx,dy;gridx=gridx,gridy=gridy,maxrank=maxrank)
+    elseif method == :Cholesky
+        @assert domain(dx) == domain(dy)
+        if dx == dy
+            CholeskyLowRankFun(f,dx;grid=max(gridx,gridy),maxrank=maxrank)
+        else
+            F = CholeskyLowRankFun(f,dx;grid=max(gridx,gridy),maxrank=maxrank)
+            LowRankFun(F.A,map(b->Fun(b,dy),F.B))
         end
     end
 end
 
-LowRankFun(f::Function,dx::Domain,dy::Domain,nx...)=LowRankFun(f,Space(dx),Space(dy),nx...)
-LowRankFun(f,d::ProductDomain)=LowRankFun(f,d[1],d[2])
+## Standard adaptive construction
+
+function standardLowRankFun(f::Function,dx::FunctionSpace,dy::FunctionSpace;gridx::Integer=64,gridy::Integer=64,maxrank::Integer=100)
+    xy = checkpoints(dx⊗dy)
+    T = promote_type(eltype(f(first(xy)...)),eltype(dx),eltype(dy))
+
+    # We start by sampling on the given grid, find the approximate maximum and create the first rank-one approximation.
+    ptsx,ptsy=points(dx,gridx),points(dy,gridy)
+    X = zeros(T,gridx,gridy)
+    maxabsf,r=findapproxmax!(f,X,ptsx,ptsy,gridx,gridy)
+    if maxabsf < eps(zero(T))/eps(T) return LowRankFun([Fun([zero(T)],dx)],[Fun([zero(T)],dy)]) end
+    a,b=Fun(x->f(x,r[2]),dx),Fun(y->f(r[1],y),dy)
+
+    # If necessary, we resize the grid to be at least as large as the
+    # lengths of the first row and column Funs and we recompute the values of X.
+    if gridx < length(a) || gridy < length(b)
+        gridx,gridy = max(gridx,length(a)),max(gridy,length(b))
+        ptsx,ptsy=points(dx,gridx),points(dy,gridy)
+        X = zeros(T,gridx,gridy)
+        maxabsf,r=findapproxmax!(f,X,ptsx,ptsy,gridx,gridy)
+        a,b=Fun(x->f(x,r[2]),dx),Fun(y->f(r[1],y),dy)
+    end
+
+    A,B,tol=typeof(a)[],typeof(b)[],100maxabsf*eps(T)
+    tol10 = tol/10
+
+    # Eat, drink, subtract rank-one, repeat.
+    for k=1:maxrank
+        if norm(a.coefficients,Inf) < tol || norm(b.coefficients,Inf) < tol return LowRankFun(A,B) end
+        A,B=[A;a/sqrt(abs(a[r[1]]))],[B;b/(sqrt(abs(b[r[2]]))*sign(b[r[2]]))]
+        maxabsf,r=findapproxmax!(A[k],B[k],X,ptsx,ptsy,gridx,gridy)
+        Ar,Br=map(q->q[r[1]],A),map(q->q[r[2]],B)
+        a,b=Fun(x->f(x,r[2]),dx,gridx) - dot(conj(Br),A),Fun(y->f(r[1],y),dy,gridy) - dot(conj(Ar),B)
+        chop!(a,tol10),chop!(b,tol10)
+    end
+    warn("Maximum rank of " * string(maxrank) * " reached")
+    return LowRankFun(A,B)
+end
+
+## Adaptive Cholesky decomposition, when f is Hermitian positive (negative) definite
+
+function CholeskyLowRankFun(f::Function,dx::FunctionSpace;grid::Integer=64,maxrank::Integer=100)
+    xy = checkpoints(dx⊗dx)
+    T = promote_type(eltype(f(first(xy)...)),eltype(dx))
+
+    # We start by sampling on the given grid, find the approximate maximum and create the first rank-one approximation.
+    pts=points(dx,grid)
+    X = zeros(T,grid)
+    maxabsf,r=findcholeskyapproxmax!(f,X,pts,grid)
+    if maxabsf < eps(zero(T))/eps(T) return LowRankFun([Fun([zero(T)],dx)],[Fun([zero(T)],dy)]) end
+    a=Fun(x->f(x,r),dx)
+
+    # If necessary, we resize the grid to be at least as large as the
+    # length of the first row/column Fun and we recompute the values of X.
+    if grid < length(a)
+        grid = max(grid,length(a))
+        pts=points(dx,grid)
+        X = zeros(T,grid)
+        maxabsf,r=findcholeskyapproxmax!(f,X,pts,grid)
+        a=Fun(x->f(x,r),dx)
+    end
+
+    A,B,tol=typeof(a)[],typeof(a)[],100maxabsf*eps(T)
+    tol10 = tol/10
+
+    # Eat, drink, subtract rank-one, repeat.
+    for k=1:maxrank
+        if norm(a.coefficients,Inf) < tol || maxabsf < eps(zero(T))/eps(T) return LowRankFun(A,B) end
+        A,B=[A;a/sqrt(abs(a[r]))],[B;a/(sqrt(abs(a[r]))*sign(a[r]))]
+        maxabsf,r=findcholeskyapproxmax!(A[k],B[k],X,pts,grid)
+        Br=map(q->q[r],B)
+        a=Fun(x->f(x,r),dx,grid) - dot(conj(Br),A)
+        chop!(a,tol10)
+    end
+    warn("Maximum rank of " * string(maxrank) * " reached")
+    return LowRankFun(A,B)
+end
+
+
+## Construction via TensorSpaces and ProductDomains
+
+LowRankFun{SV,T}(f::Function,S::TensorSpace{SV,T,2};kwds...)=LowRankFun(f,S[1],S[2];kwds...)
+LowRankFun(f::Function,dx::Domain,dy::Domain;kwds...)=LowRankFun(f,Space(dx),Space(dy);kwds...)
+LowRankFun{D,T}(f::Function,d::ProductDomain{D,T,2};kwds...)=LowRankFun(f,d[1],d[2];kwds...)
+
+LowRankFun(f::Function,d1::Vector,d2::Vector;kwds...)=LowRankFun(f,Interval(d1),Interval(d2);kwds...)
+LowRankFun(f::Function;kwds...)=LowRankFun(f,Interval(),Interval();kwds...)
+
+## Construction from values
+
+LowRankFun{T<:Number}(A::Array{T})=LowRankFun(A,Interval{T}(),Interval{T}())
+LowRankFun(c::Number,etc...)=LowRankFun((x,y)->c,etc...)
+
+## Construction from other LowRankFuns
+
+LowRankFun(f::LowRankFun,d1::IntervalDomain,d2::IntervalDomain)=LowRankFun(map(g->Fun(g.coefficients,d1),f.A),map(g->Fun(g.coefficients,d2),f.B))
+LowRankFun(f::LowRankFun)=LowRankFun(f,Interval(),Interval())
+
+
+
+## Utilities
 
 function findapproxmax!(f::Function,X::Matrix,ptsx::Vector,ptsy::Vector,gridx,gridy)
     @inbounds for j=1:gridy,k=1:gridx
@@ -73,67 +186,25 @@ function findapproxmax!(A::Fun,B::Fun,X::Matrix,ptsx::Vector,ptsy::Vector,gridx,
     maxabsf,[ptsx[imptple[1]],ptsy[imptple[2]]]
 end
 
-function LowRankFun(f::Function,dx::FunctionSpace,dy::FunctionSpace;gridx::Integer=64,gridy::Integer=64,maxrank::Integer=100)
-
-    Td = promote_type(eltype(domain(dx)),eltype(domain(dy)))
-
-    # We start by sampling on the given grid, find the approximate maximum and create the first rank-one approximation.
-    ptsx,ptsy=points(dx,gridx),points(dy,gridy)
-    Tf = typeof(f(ptsx[1],ptsy[2]))
-    T = promote_type(Tf,Td)
-    X = zeros(T,gridx,gridy)
-    maxabsf,r=findapproxmax!(f,X,ptsx,ptsy,gridx,gridy)
-    a,b=Fun(x->f(x,r[2]),dx),Fun(y->f(r[1],y),dy)
-
-    # If necessary, we resize the grid to be at least as large as the
-    # lengths of the first row and column Funs and we recompute the values of X.
-    if gridx < length(a) || gridy < length(b)
-        gridx,gridy = max(gridx,length(a)),max(gridy,length(b))
-        ptsx,ptsy=points(dx,gridx),points(dy,gridy)
-        X = zeros(T,gridx,gridy)
-        maxabsf,r=findapproxmax!(f,X,ptsx,ptsy,gridx,gridy)
-        a,b=Fun(x->f(x,r[2]),dx),Fun(y->f(r[1],y),dy)
+function findcholeskyapproxmax!(f::Function,X::Vector,pts::Vector,grid)
+    @inbounds for k=1:grid
+        X[k]+=f(pts[k],pts[k])
     end
-
-    A,B,tol=typeof(a)[],typeof(b)[],100maxabsf*eps(T)
-    tol10 = tol/10
-
-    # Eat, drink, subtract rank-one, repeat.
-    for k=1:maxrank
-
-        if norm(a.coefficients,Inf) < tol || norm(b.coefficients,Inf) < tol return LowRankFun(A,B) end
-
-        A,B=[A;a/sqrt(abs(a[r[1]]))],[B;b/(sqrt(abs(b[r[2]]))*sign(b[r[2]]))]
-
-        maxabsf,r=findapproxmax!(A[k],B[k],X,ptsx,ptsy,gridx,gridy)
-
-        Ar,Br=map(q->q[r[1]],A),map(q->q[r[2]],B)
-
-        a,b=Fun(x->f(x,r[2]),dx,gridx) - dot(conj(Br),A),Fun(y->f(r[1],y),dy,gridy) - dot(conj(Ar),B)
-
-        chop!(a,tol10),chop!(b,tol10)
-
-    end
-    warn("Maximum rank of " * string(maxrank) * " reached")
-    return LowRankFun(A,B)
+    maxabsf,impt = findmax(abs(X))
+    maxabsf,pts[impt]
 end
 
-
-
-LowRankFun(f::Function,d1::Vector,d2::Vector)=LowRankFun(f,Interval(d1),Interval(d2))
-LowRankFun(f::Function)=LowRankFun(f,Interval(),Interval())
-
-LowRankFun(f::LowRankFun,d1::IntervalDomain,d2::IntervalDomain)=LowRankFun(map(g->Fun(g.coefficients,d1),f.A),map(g->Fun(g.coefficients,d2),f.B))
-
-LowRankFun(f::LowRankFun)=LowRankFun(f,Interval(),Interval())
+function findcholeskyapproxmax!(A::Fun,B::Fun,X::Vector,pts::Vector,grid)
+    dX = A[pts].*B[pts]
+    X[:] -= dX[:]
+    maxabsf,impt = findmax(abs(X))
+    maxabsf,pts[impt]
+end
 
 
 domain(f::LowRankFun,k::Integer)=k==1? domain(first(f.A)) : domain(first(f.B))
 space(f::LowRankFun,k::Integer)=k==1? space(first(f.A)) : space(first(f.B))
 
-
-Base.size(f::LowRankFun,k::Integer)=k==1?mapreduce(length,max,f.A):mapreduce(length,max,f.B)
-Base.size(f::LowRankFun)=size(f,1),size(f,2)
 
 function values(f::LowRankFun)
     xm=mapreduce(length,max,f.A)
@@ -178,6 +249,7 @@ end
 
 
 
+evaluate{T<:Fun,M<:Fun}(A::Vector{T},B::Vector{M},x,y)=dotu(evaluate(A,x),evaluate(B,y))
 
 evaluate(f::LowRankFun,x,y)=evaluate(f.A,f.B,x,y)
 evaluate(f::LowRankFun,::Colon,::Colon)=f
@@ -196,10 +268,6 @@ function evaluate(f::LowRankFun,::Colon,y)
     Fun(ret,first(f.A).space)
 end
 
-
-
-Base.rank(f::LowRankFun)=length(f.A)
-evaluate{T<:Fun,M<:Fun}(A::Vector{T},B::Vector{M},x,y)=dotu(evaluate(A,x),evaluate(B,y))
 
 ## Truncate
 #TODO: should reduce rank if needed

--- a/src/Multivariate/ProductFun.jl
+++ b/src/Multivariate/ProductFun.jl
@@ -32,7 +32,7 @@ function ProductFun{S<:FunctionSpace,V<:FunctionSpace,T<:Number}(M::Vector{Fun{S
     ProductFun{S,V,ProductSpace{S,V},T}(funs,ProductSpace(typeof(S)[space(fun) for fun in funs],dy))
 end
 
-## Adaptive Construction
+## Adaptive construction
 
 function ProductFun{S<:FunctionSpace,V<:FunctionSpace}(f::Function,sp::AbstractProductSpace{(S,V)};tol=100eps())
     for n = 50:100:5000


### PR DESCRIPTION
Reorganize the methods

add safety for LowRankFun((x,y)->0.0);
based on the epsilon of zero in that precision divided by the type’s
epsilon.

add methods for constants: LowRankFun(10+im);

add Cholesky factorization of a Hermitian positive (negative) definite
cmatrix

Since that is only a property of the function & domains, and not the
spaces, if the spaces don’t match, we first create it with the dx
space, then convert coefficients of the B Funs. This has the advantage
of still only creating half the Funs in the adaptive stage, then
converting in O(n) arithmetic afterwards.

f(x,y) = besselj0(100(y-x))
@time F = LowRankFun(f);#method=:standard is the default
@time G = LowRankFun(f;method=:Cholesky);