### PR TITLE
LowRankFun space

### DIFF
--- a/src/Extras/sample.jl
+++ b/src/Extras/sample.jl
@@ -172,7 +172,7 @@ samplecdf(v::Vector)=chebbisectioninv(v,rand())
 
 sample{TS<:AbstractProductSpace}(f::Fun{TS},k::Integer)=sample(ProductFun(f),k)
 
-function sample(f::LowRankFun{Chebyshev,Chebyshev,Float64,Float64},n::Integer)
+function sample(f::LowRankFun{Chebyshev,Chebyshev,AbstractProductSpace{(Chebyshev,Chebyshev),Float64,2},Float64,Float64},n::Integer)
     ry=sample(sum(f,1),n)
     fA=evaluate(f.A,ry)
     CB=coefficients(f.B)
@@ -208,7 +208,7 @@ end
 
 
 
-function sample{SS}(f::LowRankFun{LineSpace{SS},LineSpace{SS},Float64,Float64},n::Integer)
+function sample{SS}(f::LowRankFun{LineSpace{SS},LineSpace{SS},AbstractProductSpace{(LineSpace{SS},LineSpace{SS}),Float64,2},Float64,Float64},n::Integer)
     cf=normalizedcumsum(sum(f,1))
     CB=coefficients(map(cumsum,f.B))
 

--- a/src/Fun/FunctionSpace.jl
+++ b/src/Fun/FunctionSpace.jl
@@ -14,9 +14,9 @@ immutable ComplexBasis end
 immutable AnyBasis end
 
 
-promote_rule(::Type{RealBasis},::Type{ComplexBasis})=ComplexBasis
-promote_rule(::Type{ComplexBasis},::Type{AnyBasis})=AnyBasis
-promote_rule(::Type{RealBasis},::Type{AnyBasis})=AnyBasis
+Base.promote_rule(::Type{RealBasis},::Type{ComplexBasis})=ComplexBasis
+Base.promote_rule(::Type{ComplexBasis},::Type{AnyBasis})=AnyBasis
+Base.promote_rule(::Type{RealBasis},::Type{AnyBasis})=AnyBasis
 
 # coefficient_type(basis,valuetype) gives the type for coefficients
 # for basis of type RealBasis/ComplexBasis and valuetype

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -190,7 +190,7 @@ end
 ## Composition with a Fun, LowRankFun, and ProductFun
 
 Base.getindex{BT,S,T}(B::Operator{BT},f::Fun{S,T}) = B*Multiplication(domainspace(B),f)
-Base.getindex{BT,S,M,T,V}(B::Operator{BT},f::LowRankFun{S,M,T,V}) = mapreduce(i->f.A[i]*B[f.B[i]],+,1:rank(f))
+Base.getindex{BT,S,M,SS,T,V}(B::Operator{BT},f::LowRankFun{S,M,SS,T,V}) = mapreduce(i->f.A[i]*B[f.B[i]],+,1:rank(f))
 Base.getindex{BT,S,V,SS,T}(B::Operator{BT},f::ProductFun{S,V,SS,T}) = mapreduce(i->f.coefficients[i]*B[Fun([zeros(promote_type(BT,T),i-1),one(promote_type(BT,T))],f.space[2])],+,1:length(f.coefficients))
 
 ## Standard Operators and linear algebra


### PR DESCRIPTION
Turns out I needed LowRankFuns to have an AbstractProductSpace because
now GreensFun’s can be built with either ProductFuns or LowRankFuns in
a TensorSpace or in the enriched CauchyWeight space in SIE (which is an AbstractProductSpace which has a
TensorSpace)