### PR TITLE
0.4 compatibility

### DIFF
--- a/src/Extras/timeevolution.jl
+++ b/src/Extras/timeevolution.jl
@@ -61,7 +61,7 @@ end
 BDF4(B::Vector,op::PDEOperator,uin::MultivariateFun,h::Real,m::Integer,glp)=BDF4(B,op,zeros(length(B)),uin,h,m,glp)
 
 
-function BDF22(B::Vector,op::PDEOperator,bcs::Vector,uin::(MultivariateFun,MultivariateFun),h::Real,m::Integer,glp)
+function BDF22(B::Vector,op::PDEOperator,bcs::Vector,uin::@compat(Tuple{MultivariateFun,MultivariateFun}),h::Real,m::Integer,glp)
     nt=size(uin[1],2)
     SBE  = discretize([B,I-h^2*op],domain(uin[1]),nt)            # backward euler for first 2 time steps
     SBDF = discretize([B,I-4.0/9.0*h^2*op],domain(uin[1]),nt)    # BDF formula for subsequent itme steps
@@ -80,7 +80,7 @@ function BDF22(B::Vector,op::PDEOperator,bcs::Vector,uin::(MultivariateFun,Multi
     u4
 end
 
-function BDF22(B::Vector,op::PDEOperator,g::Function,bcs::Vector,uin::(MultivariateFun,MultivariateFun),h::Real,m::Integer,glp)
+function BDF22(B::Vector,op::PDEOperator,g::Function,bcs::Vector,uin::@compat(Tuple{MultivariateFun,MultivariateFun}),h::Real,m::Integer,glp)
     nt=size(uin[1],2)
     SBE  = discretize([B,I-h^2*op],domain(uin[1]),nt)            # backward euler for first 2 time steps
     SBDF = discretize([B,I-4.0/9.0*h^2*op],domain(uin[1]),nt)    # BDF formula for subsequent itme steps
@@ -143,7 +143,7 @@ timeevolution(B::PDEOperator,dat...)=timeevolution([B],dat...)
 
 
 #u_tt = op*u
-function timeevolution2(B::Vector,op,bcs::Vector,uin::(MultivariateFun,MultivariateFun),h::Real,m::Integer,glp)
+function timeevolution2(B::Vector,op,bcs::Vector,uin::@compat(Tuple{MultivariateFun,MultivariateFun}),h::Real,m::Integer,glp)
     require("GLPlot")
     setplotter("GLPlot")
     nt=size(uin[1],2)
@@ -162,7 +162,7 @@ function timeevolution2(B::Vector,op,bcs::Vector,uin::(MultivariateFun,Multivari
 end
 
 #u_tt = op*u
-function timeevolution2(B::Vector,op,g::Function,bcs::Vector,uin::(MultivariateFun,MultivariateFun),h::Real,m::Integer,glp)
+function timeevolution2(B::Vector,op,g::Function,bcs::Vector,uin::@compat(Tuple{MultivariateFun,MultivariateFun}),h::Real,m::Integer,glp)
     require("GLPlot")
     setplotter("GLPlot")
     nt=size(uin[1],2)
@@ -182,23 +182,23 @@ function timeevolution2(B::Vector,op,g::Function,bcs::Vector,uin::(MultivariateF
     end    
 end
 
-function timeevolution2(B::Vector,op,uin::(MultivariateFun,MultivariateFun),bcs::Vector,h::Real,m=5000)
+function timeevolution2(B::Vector,op,uin::@compat(Tuple{MultivariateFun,MultivariateFun}),bcs::Vector,h::Real,m=5000)
     require("GLPlot")
     setplotter("GLPlot")
     timeevolution2(B,op,bcs,uin,h,m,plot(pad(uin[end],80,80)))
 end
 
-function timeevolution2(B::Vector,op,g::Function,uin::(MultivariateFun,MultivariateFun),bcs::Vector,h::Real,m=5000)
+function timeevolution2(B::Vector,op,g::Function,uin::@compat(Tuple{MultivariateFun,MultivariateFun}),bcs::Vector,h::Real,m=5000)
     require("GLPlot")
     setplotter("GLPlot")
     timeevolution2(B,op,g,bcs,uin,h,m,plot(pad(uin[end],80,80)))
 end
 
-timeevolution2(B::Vector,op,uin::(MultivariateFun,MultivariateFun),h::Real,dat...)=timeevolution2(B,op,uin,zeros(length(B)),h,dat...)
+timeevolution2(B::Vector,op,uin::@compat(Tuple{MultivariateFun,MultivariateFun}),h::Real,dat...)=timeevolution2(B,op,uin,zeros(length(B)),h,dat...)
 timeevolution2(B::Vector,op,uin::MultivariateFun,dat...)=timeevolution2(B,op,(uin,uin),dat...)
 timeevolution2(B::PDEOperator,dat...)=timeevolution2([B],dat...)
 
-timeevolution2(B::Vector,op,g::Function,uin::(MultivariateFun,MultivariateFun),h::Real,dat...)=timeevolution2(B,op,g,uin,zeros(length(B)),h,dat...)
+timeevolution2(B::Vector,op,g::Function,uin::@compat(Tuple{MultivariateFun,MultivariateFun}),h::Real,dat...)=timeevolution2(B,op,g,uin,zeros(length(B)),h,dat...)
 timeevolution2(B::Vector,op,g::Function,uin::MultivariateFun,dat...)=timeevolution2(B,op,g,(uin,uin),dat...)
 
 

--- a/src/LinearAlgebra/ShiftVector.jl
+++ b/src/LinearAlgebra/ShiftVector.jl
@@ -26,8 +26,7 @@ lastindex(sl::ShiftVector)=length(sl)-sl.index
 
 range(sv::ShiftVector)=firstindex(sv):lastindex(sv)
 
-Base.getindex(sl::ShiftVector,k::Integer)=sl.vector[k+sl.index]
-Base.getindex(sl::ShiftVector,r::Range1)=sl.vector[r+sl.index]
+Base.getindex(sl::ShiftVector,r)=sl.vector[r+sl.index]
 
 
 Base.flipud(sl::ShiftVector)=ShiftVector(flipud(sl.vector),length(sl.vector)-sl.index+1)
@@ -81,7 +80,7 @@ end
 
 #TODO f[0:end]
 
-pad(f::ShiftVector,r::Range1)=ShiftVector(
+pad(f::ShiftVector,r::UnitRange)=ShiftVector(
     padleft(f[firstindex(f):-1],-first(r)),
     pad(f[0:lastindex(f)],last(r)+1))
 
@@ -189,7 +188,7 @@ deinterlace(v::Vector)=ShiftVector(flipud(v[2:2:end]),v[1:2:end])
 
 
 
-function Base.resize!(c::ShiftVector,k::Range1)
+function Base.resize!(c::ShiftVector,k::UnitRange)
    fi=firstindex(c)
 
    splice!(c.vector,last(k)+c.index+1:length(c.vector)) 

--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -37,7 +37,7 @@ tocanonical(d::MultivariateFunctionSpace,x...)=tocanonical(domain(d),x...)
 abstract AbstractProductSpace{S,T} <: BivariateFunctionSpace
 
 immutable TensorSpace{S<:FunctionSpace,T<:FunctionSpace} <:AbstractProductSpace{S,T}
-    spaces::(S,T)
+    spaces::@compat(Tuple{S,T})
 end
 
 TensorSpace(A,B)=TensorSpace((A,B))

--- a/src/Operators/AlmostBandedOperator.jl
+++ b/src/Operators/AlmostBandedOperator.jl
@@ -87,7 +87,7 @@ type AlmostBandedOperator{T,M,R} <: BandedBelowOperator{T}
     
     datalength::Int       # How long data is.  We can't use the array length of data as we double the memory allocation but don't want to fill in
     
-    bandinds::(Int,Int)   # Encodes the bandrange
+    bandinds::@compat(Tuple{Int,Int})   # Encodes the bandrange
 end
 
 domainspace(M::AlmostBandedOperator)=domainspace(M.op)
@@ -169,7 +169,7 @@ function Base.getindex(B::AlmostBandedOperator,k::Integer,j::Integer)
 end
 
 
-# getindex!(b::AlmostBandedOperator,kr::Range1,jr::Range1)=resizedata!(b,kr[end])[kr,jr]
+# getindex!(b::AlmostBandedOperator,kr::UnitRange,jr::UnitRange)=resizedata!(b,kr[end])[kr,jr]
 # getindex!(b::AlmostBandedOperator,kr::Integer,jr::Integer)=resizedata!(b,kr)[kr,jr]
 
 function resizedata!{T<:Number,M<:BandedOperator,R}(B::AlmostBandedOperator{T,M,R},n::Integer)

--- a/src/Operators/CompactOperator.jl
+++ b/src/Operators/CompactOperator.jl
@@ -17,6 +17,6 @@ function matrix_addentries!(M::Array,A,kr::Range)
 end
 
 
-addentries!(T::CompactOperator,A,kr::Range1)=matrix_addentries!(T.matrix,A,kr)
+addentries!(T::CompactOperator,A,kr::UnitRange)=matrix_addentries!(T.matrix,A,kr)
 
 bandinds(T::CompactOperator)=(1-size(T.matrix,1),size(T.matrix,2)-1)

--- a/src/Operators/ConstantOperator.jl
+++ b/src/Operators/ConstantOperator.jl
@@ -34,7 +34,7 @@ end
 
 
 Base.getindex(op::BasisFunctional,k::Integer)=(k==op.k)?1.:0.
-Base.getindex(op::BasisFunctional,k::Range1)=convert(Vector{Float64},k.==op.k)
+Base.getindex(op::BasisFunctional,k::UnitRange)=convert(Vector{Float64},k.==op.k)
 
 immutable FillFunctional{T<:Number} <: Functional{T}
     c::T
@@ -80,7 +80,7 @@ domainspace(Z::ZeroFunctional)=Z.domainspace
 promotedomainspace(Z::ZeroFunctional,sp::FunctionSpace)=ZeroFunctional(sp)
 
 Base.getindex(op::ZeroFunctional,k::Integer)=0.
-Base.getindex(op::ZeroFunctional,k::Range1)=zeros(length(k))
+Base.getindex(op::ZeroFunctional,k::UnitRange)=zeros(length(k))
 
 
 

--- a/src/Operators/Operator.jl
+++ b/src/Operators/Operator.jl
@@ -41,7 +41,7 @@ Base.size(op::Operator,k::Integer)=size(op)[k]
 
 
 bandinds(A,k::Integer)=bandinds(A)[k]
-bandrange(b::BandedBelowOperator)=Range1(bandinds(b)...)
+bandrange(b::BandedBelowOperator)=UnitRange(bandinds(b)...)
 function bandrangelength(B::BandedBelowOperator)
     bndinds=bandinds(B)
     bndinds[end]-bndinds[1]+1

--- a/src/Operators/SavedOperator.jl
+++ b/src/Operators/SavedOperator.jl
@@ -56,7 +56,7 @@ type SavedBandedOperator{T<:Number,M<:BandedOperator} <: BandedOperator{T}
     op::M
     data::BandedMatrix{T}   #Shifted to encapsolate bandedness
     datalength::Int
-    bandinds::(Int,Int)
+    bandinds::@compat(Tuple{Int,Int})
 end
 
 

--- a/src/Operators/StrideOperator.jl
+++ b/src/Operators/StrideOperator.jl
@@ -129,7 +129,7 @@ end
 StrideFunctional{T<:Number}(B::Functional{T},r,rs)=StrideFunctional{T,typeof(B)}(B,r,rs)
 
 
-Base.getindex{T<:Number}(op::StrideFunctional{T},kr::Range1)=[((k-op.rowindex)%op.stride==0)?op.op[fld(k-op.rowindex,op.stride)]:zero(T) for k=kr]
+Base.getindex{T<:Number}(op::StrideFunctional{T},kr::UnitRange)=[((k-op.rowindex)%op.stride==0)?op.op[fld(k-op.rowindex,op.stride)]:zero(T) for k=kr]
 
 
 

--- a/src/Operators/ToeplitzOperator.jl
+++ b/src/Operators/ToeplitzOperator.jl
@@ -105,7 +105,7 @@ function hankel_addentries!(v::Vector,A,kr::Range)
 end
 
 
-addentries!(T::HankelOperator,A,kr::Range1)=hankel_addentries!(T.coefficients,A,kr)
+addentries!(T::HankelOperator,A,kr::UnitRange)=hankel_addentries!(T.coefficients,A,kr)
 
 bandinds(T::HankelOperator)=(1-length(T.coefficients),length(T.coefficients)-1)
 

--- a/src/Operators/adaptiveqr.jl
+++ b/src/Operators/adaptiveqr.jl
@@ -78,7 +78,7 @@ function givensreduce!{T<:Number,M,R}(B::AlmostBandedOperator{T,M,R},v::Array,k1
     B
 end
 
-function givensreduce!(B::AlmostBandedOperator,v::Array,k1::Range1,j1::Integer)
+function givensreduce!(B::AlmostBandedOperator,v::Array,k1::UnitRange,j1::Integer)
     if length(k1)>1
         for k=k1[2]:k1[end]
             givensreduce!(B,v,k1[1],k,j1)

--- a/src/Operators/algebra.jl
+++ b/src/Operators/algebra.jl
@@ -148,7 +148,7 @@ immutable ConstantTimesFunctional{T<:Number,B<:Functional} <: Functional{T}
     op::B
 end
 
-Base.getindex(op::ConstantTimesFunctional,k::Range1)=op.c*op.op[k]
+Base.getindex(op::ConstantTimesFunctional,k::UnitRange)=op.c*op.op[k]
 
 
 

--- a/src/Spaces/Disk/DiskSpace.jl
+++ b/src/Spaces/Disk/DiskSpace.jl
@@ -7,7 +7,7 @@ export Disk
 ##TODO: make argument 
 immutable Disk <: BivariateDomain
     radius::Float64
-    center::(Float64,Float64)
+    center::@compat(Tuple{Float64,Float64})
 end
 
 Disk(r)=Disk(r,(0.,0.))

--- a/src/Spaces/Disk/JacobiSquare.jl
+++ b/src/Spaces/Disk/JacobiSquare.jl
@@ -29,7 +29,7 @@ plan_transform(S::JacobiSquare,n)=gausschebyshev(n,4)
 transform(S::JacobiSquare,vals::Vector)=transform(S,vals,plan_transform(S,length(vals)))
 
 
-function transform(S::JacobiSquare,vals::Vector,xw::(Vector,Vector))
+function transform(S::JacobiSquare,vals::Vector,xw::@compat(Tuple{Vector,Vector}))
     m=S.m;a=S.a;b=S.b
     x,w=xw
         

--- a/src/Spaces/Jacobi/Jacobi.jl
+++ b/src/Spaces/Jacobi/Jacobi.jl
@@ -69,7 +69,7 @@ function jacobip(r::Range,α,β,x::Number)
     end
 end
 jacobip(n::Integer,α,β,v::Number)=jacobip(n:n,α,β,v)[1]
-jacobip(n::Range1,α,β,v::Vector)=hcat(map(x->jacobip(n,α,β,x),v)...).'
+jacobip(n::UnitRange,α,β,v::Vector)=hcat(map(x->jacobip(n,α,β,x),v)...).'
 jacobip(n::Integer,α,β,v::Vector)=map(x->jacobip(n,α,β,x),v)
 jacobip(n,S::Jacobi,v)=jacobip(n,S.a,S.b,v)
 

--- a/src/Spaces/Jacobi/jacobitransform.jl
+++ b/src/Spaces/Jacobi/jacobitransform.jl
@@ -34,7 +34,7 @@ end
 
 
 points(S::Jacobi,n)=fromcanonical(S,gaussjacobi(n,S.a,S.b)[1])
-function transform(S::Jacobi,v::Vector,xw::(Vector,Vector))
+function transform(S::Jacobi,v::Vector,xw::@compat(Tuple{Vector,Vector}))
     x,w=xw
     V=jacobip(0:length(v)-1,S.a,S.b,x)'
     nrm=(V.^2)*w
@@ -72,7 +72,7 @@ points(S::JacobiWeight{Jacobi},n)=fromcanonical(S,plan_transform(S,n)[1])
 
 
 transform(S::JacobiWeight{Jacobi},vals::Vector)=transform(S,vals,plan_transform(S,length(vals)))
-function transform(S::JacobiWeight{Jacobi},vals::Vector,xw::(Vector,Vector))
+function transform(S::JacobiWeight{Jacobi},vals::Vector,xw::@compat(Tuple{Vector,Vector}))
     # Jacobi and JacobiWeight have different a/b orders
     
     if S.α==0 && S.β==0

--- a/src/Spaces/Modifier/ArraySpace.jl
+++ b/src/Spaces/Modifier/ArraySpace.jl
@@ -4,14 +4,14 @@ export devec,demat,mat
 
 immutable ArraySpace{S,n,T,D<:Domain} <: FunctionSpace{T,D}
      space::S     
-     dimensions::(Int...)
+     dimensions::@compat(Tuple{Vararg{Int}})
 #      # for AnyDomain() usage
     ArraySpace(sp::S,dims)=new(sp,dims)
     ArraySpace(d::Domain,dims)=new(S(d),dims)
 end
 
 
-ArraySpace{T,D}(S::FunctionSpace{T,D},n::(Int...))=ArraySpace{typeof(S),length(n),T,D}(S,n)
+ArraySpace{T,D}(S::FunctionSpace{T,D},n::@compat(Tuple{Vararg{Int}}))=ArraySpace{typeof(S),length(n),T,D}(S,n)
 ArraySpace{T,D}(S::FunctionSpace{T,D},n::Integer)=ArraySpace(S,(n,))
 ArraySpace{T,D}(S::FunctionSpace{T,D},n,m)=ArraySpace{typeof(S),2,T,D}(S,(n,m))
 ArraySpace(S::Domain,n...)=ArraySpace(Space(S),n...)

--- a/src/Spaces/Modifier/ProductSpaceOperators.jl
+++ b/src/Spaces/Modifier/ProductSpaceOperators.jl
@@ -66,10 +66,10 @@ Base.blkdiag{FT<:PiecewiseSpace,OT<:AbstractDiagonalInterlaceOperator}(A::Multip
 
 immutable DiagonalArrayOperator{B<:BandedOperator,T<:Number} <: BandedOperator{T}
     op::B
-    dimensions::(Int...)
+    dimensions::@compat(Tuple{Vararg{Int}})
 end
 
-DiagonalArrayOperator{T}(op::BandedOperator{T},dms::(Int...))=DiagonalArrayOperator{typeof(op),T}(op,dms)
+DiagonalArrayOperator{T}(op::BandedOperator{T},dms::@compat(Tuple{Vararg{Int}}))=DiagonalArrayOperator{typeof(op),T}(op,dms)
 #DiagonalArrayOperator{T}(op::BandedOperator{T},dms::Int)=DiagonalArrayOperator(op,(dms,))
 
 

--- a/src/Spaces/Modifier/SumSpace.jl
+++ b/src/Spaces/Modifier/SumSpace.jl
@@ -4,12 +4,12 @@ export ⊕
 
 
 immutable SumSpace{S<:FunctionSpace,V<:FunctionSpace,T<:Number,D<:Domain} <: FunctionSpace{T,D}
-    spaces::(S,V)
+    spaces::@compat(Tuple{S,V})
     SumSpace(d::Domain)=new((S(d),V(d)))
-    SumSpace(sp::(S,V))=new(sp)
+    SumSpace(sp::@compat(Tuple{S,V}))=new(sp)
 end
 
-function SumSpace{T<:Number,D}(A::(FunctionSpace{T,D},FunctionSpace{T,D}))
+function SumSpace{T<:Number,D}(A::@compat(Tuple{FunctionSpace{T,D},FunctionSpace{T,D}}))
     @assert domain(A[1])==domain(A[2])
     SumSpace{typeof(A[1]),typeof(A[2]),T,D}(A)
 end

--- a/src/Spaces/Ultraspherical/DirichletSpace.jl
+++ b/src/Spaces/Ultraspherical/DirichletSpace.jl
@@ -16,8 +16,8 @@ canonicalspace(S::ChebyshevDirichlet)=Chebyshev(domain(S))
 
 ## Dirichlet Conversion
 
-addentries!(C::Conversion{ChebyshevDirichlet{1,0},Chebyshev},A,kr::Range1)=toeplitz_addentries!(ShiftVector([1.,1.],1),A,kr)
-addentries!(C::Conversion{ChebyshevDirichlet{0,1},Chebyshev},A,kr::Range1)=toeplitz_addentries!(ShiftVector([1.,-1.],1),A,kr)
+addentries!(C::Conversion{ChebyshevDirichlet{1,0},Chebyshev},A,kr::UnitRange)=toeplitz_addentries!(ShiftVector([1.,1.],1),A,kr)
+addentries!(C::Conversion{ChebyshevDirichlet{0,1},Chebyshev},A,kr::UnitRange)=toeplitz_addentries!(ShiftVector([1.,-1.],1),A,kr)
 function addentries!(C::Conversion{ChebyshevDirichlet{1,1},Chebyshev},A,kr::Range)
     A=toeplitz_addentries!(ShiftVector([1.,0.,-1.],1),A,kr)    
     if kr[1]==1

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -217,7 +217,7 @@ function addentries!{m,λ}(M::Conversion{Ultraspherical{m},Ultraspherical{λ}},A
 end
 
 function multiplyentries!(M::Conversion{Chebyshev,Ultraspherical{1}},A,kr::Range)
-    cr=columnrange(A)::Range1{Int}
+    cr=columnrange(A)::UnitRange{Int}
 
     #We assume here that the extra rows are redundant
     for k=max(2,kr[1]):kr[end]+2,j=cr
@@ -232,7 +232,7 @@ end
 
 function multiplyentries!{m,λ}(M::Conversion{Ultraspherical{m},Ultraspherical{λ}},A,kr::Range)
     @assert λ==m+1
-    cr=columnrange(A)::Range1{Int64}
+    cr=columnrange(A)::UnitRange{Int64}
 
     λf = 1.λ
 


### PR DESCRIPTION
With these changes, `using ApproxFun` works, although the tests still fail and there are many deprecation warnings (`WARNING: [a,b] concatenation is deprecated; use [a;b] instead`).