### PR TITLE
fixes Multiplication{F,ConstantSpace,T}

### DIFF
--- a/src/Spaces/Modifier/ConstantSpace.jl
+++ b/src/Spaces/Modifier/ConstantSpace.jl
@@ -34,6 +34,19 @@ function addentries!{S<:FunctionSpace}(C::Conversion{ConstantSpace,S},A,kr::Rang
     A
 end
 
+bandinds{F<:FunctionSpace,T}(D::Multiplication{F,ConstantSpace,T}) = 1-length(D.f),0
+function addentries!{F<:FunctionSpace,T}(D::Multiplication{F,ConstantSpace,T},A,kr)
+    Op = Multiplication(D.f,space(D.f))
+    for k=kr
+        if k≤length(D.f)
+            A[k,1]+=Op[k,1]
+        end
+    end
+    A
+end
+rangespace{F<:FunctionSpace,T}(D::Multiplication{F,ConstantSpace,T}) = rangespace(Multiplication(D.f,space(D.f)))
+
+
 ###
 # FunctionalOperator treats a functional like an operator
 ###


### PR DESCRIPTION
I thinnk this works. The default was adding entries of the matrix of
Multiplication values in the space of f, but from ConstantSpace we only
need the first column (Σ[F] is an operator of the same rank as F).

Not sure how the default Multiplication was interacting with the
Conversion operator from a ConstantSpace. This might be missing
something from either type promotion or array-valued spaces. The tests
passed though.

Closes #184.