### PR TITLE
Remove left over `::Function` for plans and support new DFT API

### DIFF
--- a/src/Extras/fftGeneric.jl
+++ b/src/Extras/fftGeneric.jl
@@ -46,7 +46,7 @@ plan_chebyshevtransform{T<:BigFloats}(x::Vector{T};kwds...) = identity
 plan_ichebyshevtransform{T<:BigFloats}(x::Vector{T};kwds...) = identity
 
 #following Chebfun's @Chebtech1/vals2coeffs.m and @Chebtech2/vals2coeffs.m
-function chebyshevtransform{T<:BigFloats}(x::Vector{T},plan::Function;kind::Integer=1)
+function chebyshevtransform{T<:BigFloats}(x::Vector{T},plan;kind::Integer=1)
     if kind == 1
         n = length(x)
         if n == 1
@@ -72,7 +72,7 @@ function chebyshevtransform{T<:BigFloats}(x::Vector{T},plan::Function;kind::Inte
 end
 
 #following Chebfun's @Chebtech1/vals2coeffs.m and @Chebtech2/vals2coeffs.m
-function ichebyshevtransform{T<:BigFloats}(x::Vector{T},plan::Function;kind::Integer=1)
+function ichebyshevtransform{T<:BigFloats}(x::Vector{T},plan;kind::Integer=1)
     if kind == 1
         n = length(x)
         if n == 1

--- a/src/Extras/fftGeneric.jl
+++ b/src/Extras/fftGeneric.jl
@@ -1,5 +1,19 @@
 typealias BigFloats Union(BigFloat,Complex{BigFloat})
 
+if VERSION >= v"0.4-dev"
+    # old DFT API: p(x) # deprecated
+    wrap_fft_plan(x::Function) = x
+    # new DFT API
+    immutable FFTPlanWrapper{P}
+        p::P
+    end
+    call(p::FFTPlanWrapper, arg) = p.p * arg
+    wrap_fft_plan(x) = FFTPlanWrapper(x)
+else
+    # 0.3 (old) DFT API
+    wrap_fft_plan(x) = x
+end
+
 # The following implements Bluestein's algorithm, following http://www.dsprelated.com/dspbooks/mdft/Bluestein_s_FFT_Algorithm.html
 # To add more types, add them in the union of the function's signature.
 function Base.fft{T<:BigFloats}(x::Vector{T})

--- a/src/LinearAlgebra/chebyshevtransform.jl
+++ b/src/LinearAlgebra/chebyshevtransform.jl
@@ -12,7 +12,7 @@ function plan_chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=
     end
 end
 
-function chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan::Function;kind::Integer=1)
+function chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer=1)
     if kind == 1
         n = length(x)
         if n == 1
@@ -46,7 +46,7 @@ function plan_ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer
     end
 end
 
-function ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan::Function;kind::Integer=1)
+function ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer=1)
     if kind == 1
         x[1] *=2
         ret = plan(negateeven!(x))/2

--- a/src/LinearAlgebra/chebyshevtransform.jl
+++ b/src/LinearAlgebra/chebyshevtransform.jl
@@ -6,9 +6,9 @@ export plan_chebyshevtransform, plan_ichebyshevtransform, chebyshevtransform, ic
 
 function plan_chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
     if kind == 1
-        length(x)==1?identity:FFTW.plan_r2r(x, FFTW.REDFT10)
+        length(x)==1?identity:wrap_fft_plan(FFTW.plan_r2r(x, FFTW.REDFT10))
     elseif kind == 2
-        length(x)==1?identity:FFTW.plan_r2r(x, FFTW.REDFT00)
+        length(x)==1?identity:wrap_fft_plan(FFTW.plan_r2r(x, FFTW.REDFT00))
     end
 end
 
@@ -40,9 +40,9 @@ chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)=chebyshevtr
 
 function plan_ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T};kind::Integer=1)
     if kind == 1
-        length(x)==1?identity:FFTW.plan_r2r(x, FFTW.REDFT01)
+        length(x)==1?identity:wrap_fft_plan(FFTW.plan_r2r(x, FFTW.REDFT01))
     elseif kind == 2
-        length(x)==1?identity:FFTW.plan_r2r(x, FFTW.REDFT00)
+        length(x)==1?identity:wrap_fft_plan(FFTW.plan_r2r(x, FFTW.REDFT00))
     end
 end
 

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -207,8 +207,8 @@ end
 
 ##FFT That interlaces coefficients
 
-plan_svfft(x::Vector) = plan_fft(x)
-plan_isvfft(x::Vector) = plan_ifft(x)
+plan_svfft(x::Vector) = wrap_fft_plan(plan_fft(x))
+plan_isvfft(x::Vector) = wrap_fft_plan(plan_ifft(x))
 
 function svfft(v::Vector,plan)
     n=length(v)

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -210,7 +210,7 @@ end
 plan_svfft(x::Vector) = plan_fft(x)
 plan_isvfft(x::Vector) = plan_ifft(x)
 
-function svfft(v::Vector,plan::Function)
+function svfft(v::Vector,plan)
     n=length(v)
     v=plan(v)/n
     if mod(n,2) == 0
@@ -229,7 +229,7 @@ function svfft(v::Vector,plan::Function)
     end
 end
 
-function isvfft(sv::Vector,plan::Function)
+function isvfft(sv::Vector,plan)
     n=length(sv)
 
     if mod(n,2) == 0

--- a/src/Spaces/Fourier/Fourier.jl
+++ b/src/Spaces/Fourier/Fourier.jl
@@ -28,13 +28,13 @@ spacescompatible{s}(a::Hardy{s},b::Hardy{s})=domainscompatible(a,b)
 
 typealias Taylor Hardy{true}
 
-plan_transform(::Taylor,x::Vector)=plan_fft(x)
-plan_itransform(::Taylor,x::Vector)=plan_ifft(x)
+plan_transform(::Taylor,x::Vector)=wrap_fft_plan(plan_fft(x))
+plan_itransform(::Taylor,x::Vector)=wrap_fft_plan(plan_ifft(x))
 transform(::Taylor,vals::Vector,plan)=alternatesign!(plan(vals)/length(vals))
 itransform(::Taylor,cfs::Vector,plan)=plan(alternatesign!(cfs))*length(cfs)
 
-plan_transform(::Hardy{false},x::Vector)=plan_fft(x)
-plan_itransform(::Hardy{false},x::Vector)=plan_ifft(x)
+plan_transform(::Hardy{false},x::Vector)=wrap_fft_plan(plan_fft(x))
+plan_itransform(::Hardy{false},x::Vector)=wrap_fft_plan(plan_ifft(x))
 transform(::Hardy{false},vals::Vector,plan)=-alternatesign!(flipdim(plan(vals),1)/length(vals))
 itransform(::Hardy{false},cfs::Vector,plan)=plan(flipdim(alternatesign!(-cfs),1))*length(cfs)
 
@@ -100,8 +100,8 @@ evaluate(f::Fun{CosSpace},t)=clenshaw(f.coefficients,cos(tocanonical(f,t)))
 
 
 points(sp::SinSpace,n)=points(domain(sp),2n+2)[n+3:2n+2]
-plan_transform{T<:FFTW.fftwNumber}(::SinSpace,x::Vector{T})=FFTW.plan_r2r(x,FFTW.RODFT00)
-plan_itransform{T<:FFTW.fftwNumber}(::SinSpace,x::Vector{T})=FFTW.plan_r2r(x,FFTW.RODFT00)
+plan_transform{T<:FFTW.fftwNumber}(::SinSpace,x::Vector{T})=wrap_fft_plan(FFTW.plan_r2r(x,FFTW.RODFT00))
+plan_itransform{T<:FFTW.fftwNumber}(::SinSpace,x::Vector{T})=wrap_fft_plan(FFTW.plan_r2r(x,FFTW.RODFT00))
 transform(::SinSpace,vals,plan)=plan(vals)/(length(vals)+1)
 itransform(::SinSpace,cfs,plan)=plan(cfs)/2
 evaluate(f::Fun{SinSpace},t)=sineshaw(f.coefficients,tocanonical(f,t))
@@ -131,8 +131,8 @@ Fourier{T<:Number}(d::Vector{T}) = Fourier(PeriodicInterval(d))
 
 
 points(sp::Fourier,n)=points(domain(sp),n)
-plan_transform{T<:FFTW.fftwNumber}(::Fourier,x::Vector{T}) = FFTW.plan_r2r(x, FFTW.R2HC)
-plan_itransform{T<:FFTW.fftwNumber}(::Fourier,x::Vector{T}) = FFTW.plan_r2r(x, FFTW.HC2R)
+plan_transform{T<:FFTW.fftwNumber}(::Fourier,x::Vector{T}) = wrap_fft_plan(FFTW.plan_r2r(x, FFTW.R2HC))
+plan_itransform{T<:FFTW.fftwNumber}(::Fourier,x::Vector{T}) = wrap_fft_plan(FFTW.plan_r2r(x, FFTW.HC2R))
 
 function transform{T<:Number}(::Fourier,vals::Vector{T},plan)
     n=length(vals)


### PR DESCRIPTION
This should support both new and old API on 0.4 and 0.3 (local test passed).