### PR TITLE
Feat general Clenshaw's algorithm

### DIFF
--- a/src/ApproxFun.jl
+++ b/src/ApproxFun.jl
@@ -11,7 +11,7 @@ import Base: values,getindex,setindex!,*,.*,+,.+,-,.-,==,<,<=,>,
 export pad!,pad,sample,chop!,complexroots,roots,svfft
 
 ##Testing
-export bisectioninv, clenshaw
+export bisectioninv
 
 
 

--- a/src/Extras/roots.jl
+++ b/src/Extras/roots.jl
@@ -133,8 +133,8 @@ function PruneOptions( r, htol::Float64 )
     return r
 end
 
-rootsunit_coeffs{T<:Number}(c::Vector{T}, htol::Float64)=rootsunit_coeffs(c,htol,ClenshawPlan(T,length(c)))
-function rootsunit_coeffs{T<:Number}(c::Vector{T}, htol::Float64,clplan::ClenshawPlan{T})
+rootsunit_coeffs{T<:Number}(c::Vector{T}, htol::Float64)=rootsunit_coeffs(c,htol,ClenshawPlan(T,Chebyshev(),length(c),length(c)))
+function rootsunit_coeffs{S,T<:Number}(c::Vector{T}, htol::Float64,clplan::ClenshawPlan{S,T})
 # Computes the roots of the polynomial given by the coefficients c on the unit interval.
 
 

--- a/src/Extras/sample.jl
+++ b/src/Extras/sample.jl
@@ -41,8 +41,8 @@ function chebbisectioninv(c::Vector{Float64},x::Float64;numits::Int=47)
 end
 
 
-chebbisectioninv(c::Vector{Float64},xl::Vector{Float64})=(n=length(xl);chebbisectioninv(c,xl,ClenshawPlan(Float64,n)))
-function chebbisectioninv(c::Vector{Float64},xl::Vector{Float64},plan::ClenshawPlan{Float64})
+chebbisectioninv(c::Vector{Float64},xl::Vector{Float64})=(n=length(xl);chebbisectioninv(c,xl,ClenshawPlan(Float64,Chebyshev(),length(c),n)))
+function chebbisectioninv{D<:Domain}(c::Vector{Float64},xl::Vector{Float64},plan::ClenshawPlan{Chebyshev{D},Float64})
     n = length(xl)
     a = -ones(n)
     b = ones(n)
@@ -61,8 +61,8 @@ end
 
 
 #here, xl is vector w/ length == #cols of c
-chebbisectioninv(c::Array{Float64,2},xl::Vector{Float64})=(n=length(xl);chebbisectioninv(c,xl,ClenshawPlan(Float64,n)))
-function chebbisectioninv(c::Array{Float64,2},xl::Vector{Float64},plan::ClenshawPlan{Float64})
+chebbisectioninv(c::Array{Float64,2},xl::Vector{Float64})=(n=length(xl);chebbisectioninv(c,xl,ClenshawPlan(Float64,Chebyshev(),size(c,1),n)))
+function chebbisectioninv{D<:Domain}(c::Array{Float64,2},xl::Vector{Float64},plan::ClenshawPlan{Chebyshev{D},Float64})
     @assert size(c)[2] == length(xl)
 
     n = length(xl)

--- a/src/LinearAlgebra/clenshaw.jl
+++ b/src/LinearAlgebra/clenshaw.jl
@@ -1,48 +1,74 @@
-type ClenshawPlan{T}
+type ClenshawPlan{S,T}
+    sp::S
     bk::Vector{T}
     bk1::Vector{T}
     bk2::Vector{T}
+    rα::Vector{T}
+    rβ::Vector{T}
+    rγ::Vector{T}
 end
 
-ClenshawPlan{T}(::Type{T},n::Integer)=ClenshawPlan(Array(T,n),Array(T,n),Array(T,n))
+function ClenshawPlan{S,T}(::Type{T},sp::S,N::Int,n::Int)
+    rα = T[recα(T,sp,k) for k=1:N]
+    rβ = T[recβ(T,sp,k) for k=1:N+1]
+    rγ = T[recγ(T,sp,k) for k=1:N]
+    ClenshawPlan(sp,Array(T,n),Array(T,n),Array(T,n),rα,rβ,rγ)
+end
 
-function clenshaw(c::Vector,x)
+function clenshaw{S,U,V}(sp::S,c::AbstractVector{U},x::V)
+    N,T = length(c),promote_type(U,V)
     if isempty(c)
         return zero(x)
     end
 
-    x = 2x
-    bk1,bk2 = zero(x),zero(x)
-    for k = length(c):-1:2
-        bk2, bk1 = bk1, c[k] + x*bk1 - bk2
+    bk1,bk2 = zero(T),zero(T)
+    rα1,rβ1,rβ2,rγ2 = recα(T,sp,N),recβ(T,sp,N),recβ(T,sp,N+1),recγ(T,sp,N+1)
+    for k = N:-1:2
+        bk2, bk1 = bk1, muladd((x-rα1)/rβ1,bk1,muladd(-rγ2/rβ2,bk2,c[k]))
+        ra1,rβ1,rβ2,rγ2 = recα(T,sp,k-1),recβ(T,sp,k-1),rβ1,recγ(T,sp,k)
     end
 
-    c[1] + x/2*bk1 - bk2
+    muladd((x-rα1)/rβ1,bk1,muladd(-rγ2/rβ2,bk2,c[1]))
 end
 
-function sineshaw(c::Vector,θ::Number)
-    if isempty(c)
-        return zero(θ)
-    end
+clenshaw{S,T,U}(sp::S,c::AbstractVector{T},x::AbstractVector{U}) = clenshaw(c,x,ClenshawPlan(promote_type(T,U),sp,length(c),length(x)))
 
-    x = 2cos(θ)
-    bk1,bk2 = zero(x),zero(x)
-    for k = length(c):-1:1
-        bk2, bk1 = bk1, c[k] + x*bk1 - bk2
-    end
-
-    sin(θ)*bk1
-end
-sineshaw(c::Vector,θ::Vector) = map(θ->sineshaw(c,θ),θ)
-
-function clenshaw{T<:Number,M<:Number}(c::Vector{T},x::Vector{M})
+function clenshaw{S,T,U,V}(c::AbstractVector{T},x::AbstractVector{U},plan::ClenshawPlan{S,V})
+    N,n = length(c),length(x)
     if isempty(c)
         return zeros(x)
     end
 
-    n = length(x)
-    clenshaw(c,x,ClenshawPlan(promote_type(T,M),n))
+    bk=plan.bk
+    bk1=plan.bk1
+    bk2=plan.bk2
+    rα=plan.rα
+    rβ=plan.rβ
+    rγ=plan.rγ
+
+    @inbounds for i = 1:n
+        bk1[i] = zero(V)
+        bk2[i] = zero(V)
+    end
+
+    @inbounds for k = N:-1:2
+        ck,rα1,rβ1,rβ2,rγ2 = c[k],rα[k],rβ[k],rβ[k+1],rγ[k+1]
+        for i = 1:n
+            bk[i] = muladd((x[i]-rα1)/rβ1,bk1[i],muladd(-rγ2/rβ2,bk2[i],ck))
+        end
+        bk2, bk1, bk = bk1, bk, bk2
+    end
+
+    ck,rα1,rβ1,rβ2,rγ2 = c[1],rα[1],rβ[1],rβ[2],rγ[2]
+    @inbounds for i = 1:n
+        bk[i] = muladd((x[i]-rα1)/rβ1,bk1[i],muladd(-rγ2/rβ2,bk2[i],ck))
+    end
+
+    bk
 end
+
+
+########################################################################################################
 
 
 #Clenshaw routine for many Funs, x is a vector of same number of funs
@@ -118,43 +144,6 @@ function clenshaw{T<:Number}(c::Array{T,2},x::Number,plan::ClenshawPlan{T})
 end
 
 
-#Clenshaw routine for many points
-#Note that bk1, bk2, and bk are overwritten
-function clenshaw{T<:Number,M<:Number,Q<:Number}(c::Vector{T},x::Vector{M},plan::ClenshawPlan{Q})
-    if isempty(c)
-        return(zeros(x))
-    end
-
-    bk=plan.bk
-    bk1=plan.bk1
-    bk2=plan.bk2
-
-    n = length(x)
-#    x=2x
-
-
-    for i = 1:n
-        @inbounds bk1[i] = zero(Q)
-        @inbounds bk2[i] = zero(Q)
-        @inbounds bk[i] = zero(Q)
-    end
-
-    for k in  length(c):-1:2
-        ck = c[k]
-        for i in 1:n
-            @inbounds bk[i] = ck + 2x[i] * bk1[i] - bk2[i]
-        end
-        bk2, bk1, bk = bk1, bk, bk2
-    end
-
-    ce = c[1]
-    for i in 1:n
-        @inbounds  bk[i] = ce + x[i]*bk1[i] - bk2[i]
-    end
-
-    bk
-end
-
 
 # overwrite x
 clenshaw!{T<:Number,M<:Number}(c::Vector{T},x::Vector{M})=clenshaw!(c,x,ClenshawPlan(promote_type(T,M),length(x)))
@@ -196,3 +185,17 @@ function clenshaw!{T<:Number,M<:Number,Q<:Number}(c::Vector{T},x::Vector{M},plan
 end
 
 
+function sineshaw(c::Vector,θ::Number)
+    if isempty(c)
+        return zero(θ)
+    end
+
+    x = 2cos(θ)
+    bk1,bk2 = zero(x),zero(x)
+    for k = length(c):-1:1
+        bk2, bk1 = bk1, muladd(x,bk1,c[k]-bk2)
+    end
+
+    sin(θ)*bk1
+end
+sineshaw(c::Vector,θ::Vector) = promote_type(eltype(c),eltype(θ))[sineshaw(c,θ[k]) for k=1:length(θ)]

--- a/src/Multivariate/VectorFun.jl
+++ b/src/Multivariate/VectorFun.jl
@@ -80,7 +80,7 @@ function evaluate{T<:Fun}(A::Vector{T},x::Vector{Float64})
     n=length(x)
     ret=Array(Float64,length(A),n)
 
-    cplan=ClenshawPlan(Float64,n)
+    cplan=ClenshawPlan(Float64,Chebyshev(),mapreduce(length,max,A),n)
 
     for k=1:length(A)
         bkr=clenshaw(A[k].coefficients,x,cplan)

--- a/src/Spaces/Fourier/Fourier.jl
+++ b/src/Spaces/Fourier/Fourier.jl
@@ -115,7 +115,7 @@ plan_transform(::CosSpace,x::Vector)=plan_chebyshevtransform(x;kind=2)
 plan_itransform(::CosSpace,x::Vector)=plan_ichebyshevtransform(x;kind=2)
 transform(::CosSpace,vals,plan)=chebyshevtransform(vals,plan;kind=2)
 itransform(::CosSpace,cfs,plan)=ichebyshevtransform(cfs,plan;kind=2)
-evaluate{CS<:CosSpace}(f::Fun{CS},t)=clenshaw(f.coefficients,cos(tocanonical(f,t)))
+evaluate{CS<:CosSpace}(f::Fun{CS},t)=clenshaw(Chebyshev(),f.coefficients,cos(tocanonical(f,t)))
 
 
 points(sp::SinSpace,n)=points(domain(sp),2n+2)[n+3:2n+2]

--- a/src/Spaces/Hermite/Hermite.jl
+++ b/src/Spaces/Hermite/Hermite.jl
@@ -19,6 +19,7 @@ spacescompatible(::Hermite,::Hermite)=true #TODO:L
 
 
 recα(::Type,::Hermite,k)=0;recβ(::Type,::Hermite,k)=0.5;recγ(::Type,::Hermite,k)=k-1
+recA(::Type,::Hermite,k)=2;recB(::Type,::Hermite,k)=0;recC(::Type,::Hermite,k)=2k
 
 bandinds{H<:Hermite}(D::Derivative{H})=0,D.order
 rangespace{H<:Hermite}(D::Derivative{H})=domainspace(D)

--- a/src/Spaces/Hermite/hermitetransform.jl
+++ b/src/Spaces/Hermite/hermitetransform.jl
@@ -11,5 +11,5 @@ function transform(H::Hermite,vals,plan::Tuple{Vector,Vector})
 end
 itransform(H::Hermite,cfs,plan::Vector) = hermitep(0:length(cfs)-1,tocanonical(H,plan))*cfs
 
-evaluate{H<:Hermite}(f::Fun{H},x::Number)=dot(hermitep(0:length(f)-1,x),f.coefficients)
-evaluate{H<:Hermite}(f::Fun{H},x::Vector)=hermitep(0:length(f)-1,x)*f.coefficients
+#evaluate{H<:Hermite}(f::Fun{H},x::Number)=dot(hermitep(0:length(f)-1,x),f.coefficients)
+#evaluate{H<:Hermite}(f::Fun{H},x::Vector)=hermitep(0:length(f)-1,x)*f.coefficients

--- a/src/Spaces/Jacobi/Jacobi.jl
+++ b/src/Spaces/Jacobi/Jacobi.jl
@@ -42,7 +42,8 @@ jacobirecγ(α,β,k)=jacobirecC(α,β,k-1)/jacobirecA(α,β,k-1)
 jacobirecα(α,β,k)=-jacobirecB(α,β,k-1)/jacobirecA(α,β,k-1)
 jacobirecβ(α,β,k)=1/jacobirecA(α,β,k-1)
 
-for (REC,JREC) in ((:recα,:jacobirecα),(:recβ,:jacobirecβ),(:recγ,:jacobirecγ))
+for (REC,JREC) in ((:recα,:jacobirecα),(:recβ,:jacobirecβ),(:recγ,:jacobirecγ),
+                   (:recA,:jacobirecA),(:recB,:jacobirecB),(:recC,:jacobirecC))
     @eval $REC(::Type,sp::Jacobi,k)=$JREC(sp.a,sp.b,k)  #TODO: implement typing
 end
 

--- a/src/Spaces/Jacobi/jacobitransform.jl
+++ b/src/Spaces/Jacobi/jacobitransform.jl
@@ -12,5 +12,5 @@ function transform(S::Jacobi,vals,plan::Tuple{Vector,Vector})
 end
 itransform(S::Jacobi,cfs,plan::Vector) = jacobip(0:length(cfs)-1,S.a,S.b,tocanonical(S,plan))*cfs
 
-evaluate{J<:Jacobi}(f::Fun{J},x::Number)=length(f)==0?zero(x):dot(jacobip(0:length(f)-1,f.space.a,f.space.b,tocanonical(f,x)),f.coefficients)
-evaluate{J<:Jacobi}(f::Fun{J},x::Vector)=jacobip(0:length(f)-1,f.space.a,f.space.b,tocanonical(f,x))*f.coefficients
+#evaluate{J<:Jacobi}(f::Fun{J},x::Number)=length(f)==0?zero(x):dot(jacobip(0:length(f)-1,f.space.a,f.space.b,tocanonical(f,x)),f.coefficients)
+#evaluate{J<:Jacobi}(f::Fun{J},x::Vector)=jacobip(0:length(f)-1,f.space.a,f.space.b,tocanonical(f,x))*f.coefficients

--- a/src/Spaces/PolynomialSpace.jl
+++ b/src/Spaces/PolynomialSpace.jl
@@ -12,6 +12,9 @@ union_rule(A::ConstantSpace,B::PolynomialSpace)=B
 Base.promote_rule{T<:Number,S<:PolynomialSpace,V}(::Type{Fun{S,V}},::Type{T})=Fun{S,promote_type(V,T)}
 Base.promote_rule{T<:Number,S<:PolynomialSpace}(::Type{Fun{S}},::Type{T})=Fun{S,T}
 
+## Evaluation
+
+evaluate{PS<:PolynomialSpace,T}(f::Fun{PS,T},x)=clenshaw(space(f),coefficients(f),tocanonical(f,x))
 
 ######
 # Recurrence encodes the recurrence coefficients

--- a/src/Spaces/Ultraspherical/DirichletSpace.jl
+++ b/src/Spaces/Ultraspherical/DirichletSpace.jl
@@ -9,6 +9,7 @@ immutable ChebyshevDirichlet{left,right,D} <: PolynomialSpace{D}
     ChebyshevDirichlet()=new(D())
 end
 
+evaluate{CD<:ChebyshevDirichlet,T}(f::Fun{CD,T},x...)=evaluate(Fun(f,canonicalspace(f)),x...)
 
 Base.convert{l,r}(::Type{ChebyshevDirichlet{l,r}})=ChebyshevDirichlet{l,r,Interval{Float64}}()
 Base.convert{l,r}(::Type{ChebyshevDirichlet{l,r}},d::Domain)=ChebyshevDirichlet{l,r,typeof(d)}(d)

--- a/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
+++ b/src/Spaces/Ultraspherical/UltrasphericalOperators.jl
@@ -1,11 +1,18 @@
 ##  Jacobi Operator
 
+recB{T}(::Type{T},::Ultraspherical,::)=zero(T)
+
+recA{T}(::Type{T},::Chebyshev,k)=2one(T)
+recC{T}(::Type{T},::Chebyshev,k)=one(T)   # one(T) ensures we get correct type
+
+recA{T,λ}(::Type{T},::Ultraspherical{λ},k)=(2*(k+λ))/(k+one(T))   # one(T) ensures we get correct type
+recC{T,λ}(::Type{T},::Ultraspherical{λ},k)=(k-one(T)+2λ)/(k+one(T))   # one(T) ensures we get correct type
+
 # x p_k
 recα{T}(::Type{T},::Ultraspherical,::)=zero(T)
 
 recβ{T}(::Type{T},::Chebyshev,k)=ifelse(k==1,one(T),one(T)/2)   # one(T) ensures we get correct type,ifelse ensures inlining
 recγ{T}(::Type{T},::Chebyshev,k)=one(T)/2   # one(T) ensures we get correct type
-
 
 recβ{T,λ}(::Type{T},::Ultraspherical{λ},k)=k/(2*(k-one(T)+λ))   # one(T) ensures we get correct type
 recγ{T,λ}(::Type{T},::Ultraspherical{λ},k)=(k-2+2λ)/(2*(k-one(T)+λ))   # one(T) ensures we get correct type


### PR DESCRIPTION
This adds the 3-term recurrence version of Clenshaw's algorithm with:
- a `ClenshawPlan` for reduced memory allocations
- in-place versions (for a general roots command)
- and `muladd` for hardware based fused multiply-add when it's available

It keeps the simpler Chebyshev methods (but changing to muladd) and also adds the @clenshaw macro similar to the Horner macro in Julia base. Now, if someone used ApproxFun to approximate a univariate function, it could perform almost as well as an elementary transcendental from standard libraries:
```julia
julia> using ApproxFun

julia> function myexp(x::Float64)
           @clenshaw(x,1.2660658777520084,1.13031820798497,0.27149533953407656,0.044336849848663804,0.005474240442093732,0.0005429263119139438,4.497732295429515e-5,3.1984364624019905e-6,1.9921248066727958e-7,1.1036771725517344e-8,5.505896079673747e-10,2.4979566169849825e-11,1.03915223067857e-12,3.9912633564144015e-14,1.4237580108256572e-15,4.740926102561496e-17)
       end
myexp (generic function with 1 method)

julia> @vectorize_1arg Float64 myexp
myexp (generic function with 4 methods)

julia> x = linspace(-1,1,1_000_000);

julia> @time myexp(x);
  0.027124 seconds (6 allocations: 7.630 MB)

julia> @time exp(x);
  0.018898 seconds (6 allocations: 7.630 MB)
```