### PR TITLE
Remove default call to ConcreteConversion

### DIFF
--- a/src/Operators/banded/Conversion.jl
+++ b/src/Operators/banded/Conversion.jl
@@ -31,23 +31,23 @@ rangespace(C::ConcreteConversion)=C.rangespace
 
 function defaultconversion(a::Space,b::Space)
     if a==b
-        ConversionWrapper(eye(a))
+        Conversion(a)
     elseif conversion_type(a,b)==NoSpace()
         sp=canonicalspace(a)
         if typeof(sp) == typeof(a)
-            error("implement Conversion from " * string(typeof(sp)) * " to " * string(typeof(b)))
+            error("Implement Conversion from " * string(typeof(sp)) * " to " * string(typeof(b)))
         elseif typeof(sp) == typeof(b)
-            error("implement Conversion from " * string(typeof(a)) * " to " * string(typeof(sp)))
+            error("Implement Conversion from " * string(typeof(a)) * " to " * string(typeof(sp)))
         else
             Conversion(a,sp,b)
         end
     else
-        ConcreteConversion(a,b)
+        error("Implement Conversion from " * string(typeof(a)) * " to " * string(typeof(b)))
     end
 end
 
 Conversion(a::Space,b::Space)=defaultconversion(a,b)
-
+Conversion(a::Space)=ConversionWrapper(eye(a))
 Conversion()=ConversionWrapper(eye(UnsetSpace()))
 
 

--- a/src/PDE/KroneckerOperator.jl
+++ b/src/PDE/KroneckerOperator.jl
@@ -309,6 +309,10 @@ conversion_rule(b::TensorSpace{AnySpace,AnySpace},a::Space)=a
 maxspace(a::TensorSpace,b::TensorSpace)=maxspace(a[1],b[1])⊗maxspace(a[2],b[2])
 
 # TODO: we explicetly state type to avoid type inference bug in 0.4
+
+ConcreteConversion(a::BivariateSpace,b::BivariateSpace)=
+    ConcreteConversion{typeof(a),typeof(b),BandedMatrix{promote_type(eltype(a),eltype(b),real(eltype(domain(a))),real(eltype(domain(b))))}}(a,b)
+
 Conversion(a::TensorSpace,b::TensorSpace)=ConversionWrapper(BandedMatrix{promote_type(eltype(a),eltype(b))},
                 KroneckerOperator(Conversion(a[1],b[1]),Conversion(a[2],b[2])))
 
@@ -319,14 +323,14 @@ function Conversion(a::BivariateSpace,b::BivariateSpace)
     elseif conversion_type(a,b)==NoSpace()
         sp=canonicalspace(a)
         if typeof(sp) == typeof(a)
-            error("implement Conversion from " * string(typeof(sp)) * " to " * string(typeof(b)))
+            error("Implement Conversion from " * string(typeof(sp)) * " to " * string(typeof(b)))
         elseif typeof(sp) == typeof(b)
-            error("implement Conversion from " * string(typeof(a)) * " to " * string(typeof(sp)))
+            error("Implement Conversion from " * string(typeof(a)) * " to " * string(typeof(sp)))
         else
             Conversion(a,sp,b)
         end
     else
-        ConcreteConversion{typeof(a),typeof(b),BandedMatrix{promote_type(eltype(a),eltype(b),real(eltype(domain(a))),real(eltype(domain(b))))}}(a,b)
+        error("Implement Conversion from " * string(typeof(sp)) * " to " * string(typeof(b)))
     end
 end
 

--- a/src/Spaces/ConstantSpace.jl
+++ b/src/Spaces/ConstantSpace.jl
@@ -79,7 +79,7 @@ union_rule(A::ConstantSpace,B::Space)=ConstantSpace(domain(B))⊕B
 Conversion{T,D}(a::ConstantSpace,b::Space{T,D,2})=ConcreteConversion{typeof(a),typeof(b),
         promote_type(op_eltype_realdomain(a),eltype(op_eltype_realdomain(b)))}(a,b)
 
-
+Conversion(a::ConstantSpace,b::Space)=ConcreteConversion(a,b)
 bandinds{CS<:ConstantSpace,S<:Space}(C::ConcreteConversion{CS,S})=1-length(ones(rangespace(C))),0
 function addentries!{CS<:ConstantSpace,S<:Space}(C::ConcreteConversion{CS,S},A,kr::Range,::Colon)
     on=ones(rangespace(C))

--- a/src/Spaces/Fourier/FourierOperators.jl
+++ b/src/Spaces/Fourier/FourierOperators.jl
@@ -9,6 +9,9 @@ coefficients{DD}(cfs::Vector,A::Laurent{DD},B::Fourier{DD})=Conversion(A,B)*cfs
 hasconversion{DD}(::Fourier{DD},::Laurent{DD})=true
 hasconversion{DD}(::Laurent{DD},::Fourier{DD})=true
 
+Conversion{DD}(a::Laurent{DD},b::Fourier{DD})=ConcreteConversion(a,b)
+Conversion{DD}(a::Fourier{DD},b::Laurent{DD})=ConcreteConversion(a,b)
+
 function addentries!{DD}(C::ConcreteConversion{Laurent{DD},Fourier{DD}},A,kr::Range,::Colon)
     for k=kr
         if k==1

--- a/src/Spaces/Fourier/LaurentDirichlet.jl
+++ b/src/Spaces/Fourier/LaurentDirichlet.jl
@@ -21,6 +21,8 @@ spacescompatible(a::LaurentDirichlet,b::LaurentDirichlet)=domainscompatible(a,b)
 
 canonicalspace(S::LaurentDirichlet)=Laurent(domain(S))
 
+
+Conversion{DD}(a::LaurentDirichlet{DD},b::Laurent{DD})=ConcreteConversion(a,b)
 bandinds{DD}(::ConcreteConversion{LaurentDirichlet{DD},Laurent{DD}})=0,2
 function addentries!{DD}(C::ConcreteConversion{LaurentDirichlet{DD},Laurent{DD}},A,kr::Range,::Colon)
     if 1 in kr
@@ -92,6 +94,7 @@ spacescompatible(a::CosDirichlet,b::CosDirichlet)=domainscompatible(a,b)
 
 canonicalspace(S::CosDirichlet)=CosSpace(domain(S))
 
+Conversion(a::CosSpace,b::CosDirichlet)=ConcreteConversion(a,b)
 bandinds{CS<:CosSpace,CD<:CosDirichlet}(::ConcreteConversion{CD,CS})=0,1
 addentries!{CS<:CosSpace,CD<:CosDirichlet}(C::ConcreteConversion{CD,CS},A,kr::Range,::Colon)=toeplitz_addentries!([],[1.,1.],A,kr)
 

--- a/src/Spaces/Modifier/SliceSpace.jl
+++ b/src/Spaces/Modifier/SliceSpace.jl
@@ -20,7 +20,7 @@ domain(DS::SliceSpace)=domain(DS.space)
 
 setdomain(DS::SliceSpace,d::Domain)=SliceSpace(setdomain(DS.space,d),index(DS),stride(DS))
 
-
+#Conversion{n,st,S<:Space,T,DD,d}(a::SliceSpace{n,st,S,T,DD,d},b::S)=ConcreteConversion(a,b)
 bandinds{n,st,S,T,DD,d}(C::ConcreteConversion{SliceSpace{n,st,S,T,DD,d},S})=-n,0
 
 function addentries!{ind,st,S,T,DD,d}(C::ConcreteConversion{SliceSpace{ind,st,S,T,DD,d},S},A,kr::Range,::Colon)

--- a/src/Spaces/Singularities/HeavisideSpace.jl
+++ b/src/Spaces/Singularities/HeavisideSpace.jl
@@ -20,6 +20,8 @@ canonicalspace(sp::HeavisideSpace)=PiecewiseSpace(map(Chebyshev,pieces(domain(sp
 
 conversion_rule{k,PS<:PolynomialSpace}(sp::HeavisideSpace,sp2::PiecewiseSpace{NTuple{k,PS}})=sp
 
+
+Conversion{kk,CC<:PolynomialSpace,DD}(a::HeavisideSpace,b::PiecewiseSpace{NTuple{kk,CC},RealBasis,DD,1})=ConcreteConversion(a,b)
 bandinds{HS<:HeavisideSpace,CC<:PolynomialSpace,DD,kk}(::ConcreteConversion{HS,PiecewiseSpace{NTuple{kk,CC},RealBasis,DD,1}})=0,0
 #bandinds{HS<:HeavisideSpace,DD,D}(::ConcreteConversion{PiecewiseSpace{ChebyshevDirichlet{1,1,D},RealBasis,DD,1},HS})=0,0
 function addentries!{HS<:HeavisideSpace,CC<:PolynomialSpace,DD,kk}(C::ConcreteConversion{HS,PiecewiseSpace{NTuple{kk,CC},RealBasis,DD,1}},A,kr::Range,::Colon)

--- a/src/Spaces/Singularities/JacobiWeightOperators.jl
+++ b/src/Spaces/Singularities/JacobiWeightOperators.jl
@@ -280,8 +280,8 @@ end
 conversion_rule{T,D<:IntervalDomain}(A::JacobiWeight,B::UnivariateSpace{T,D})=conversion_type(A,JacobiWeight(0,0,B))
 
 
-
-function Conversion{JS1,JS2,DD<:IntervalDomain}(A::JacobiWeight{JS1,DD},B::JacobiWeight{JS2,DD})
+# override defaultconversion instead of Conversion to avoid ambiguity errors
+function defaultconversion{JS1,JS2,DD<:IntervalDomain}(A::JacobiWeight{JS1,DD},B::JacobiWeight{JS2,DD})
     @assert isapproxinteger(A.α-B.α) && isapproxinteger(A.β-B.β)
 
     if isapprox(A.α,B.α) && isapprox(A.β,B.β)
@@ -310,11 +310,11 @@ function Conversion{JS1,JS2,DD<:IntervalDomain}(A::JacobiWeight{JS1,DD},B::Jacob
     end
 end
 
-Conversion{JS,D<:IntervalDomain}(A::RealUnivariateSpace{D},B::JacobiWeight{JS,D})=ConversionWrapper(
+defaultconversion{JS,D<:IntervalDomain}(A::RealUnivariateSpace{D},B::JacobiWeight{JS,D})=ConversionWrapper(
     SpaceOperator(
         Conversion(JacobiWeight(0,0,A),B),
         A,B))
-Conversion{JS,D<:IntervalDomain}(A::JacobiWeight{JS,D},B::RealUnivariateSpace{D})=ConversionWrapper(
+defaultconversion{JS,D<:IntervalDomain}(A::JacobiWeight{JS,D},B::RealUnivariateSpace{D})=ConversionWrapper(
     SpaceOperator(
         Conversion(A,JacobiWeight(0,0,B)),
         A,B))

--- a/src/Spaces/Ultraspherical/ContinuousSpace.jl
+++ b/src/Spaces/Ultraspherical/ContinuousSpace.jl
@@ -100,6 +100,16 @@ end
 ## Conversion
 
 coefficients(cfsin::Vector,A::ContinuousSpace,B::PiecewiseSpace)=defaultcoefficients(cfsin,A,B)
+
+
+# We implemnt conversion between continuous space and PiecewiseSpace with Chebyshev dirichlet
+Conversion{CD<:Tuple{Vararg{ChebyshevDirichlet{1,1}}},DD}(ps::PiecewiseSpace{CD,RealBasis,DD,1},cs::ContinuousSpace)=
+                ConcreteConversion(ps,cs)
+
+Conversion{CD<:Tuple{Vararg{ChebyshevDirichlet{1,1}}},DD}(cs::ContinuousSpace,ps::PiecewiseSpace{CD,RealBasis,DD,1})=
+                ConcreteConversion(cs,ps)
+
+
 bandinds{CD<:Tuple{Vararg{ChebyshevDirichlet{1,1}}},DD}(C::ConcreteConversion{PiecewiseSpace{CD,RealBasis,DD,1},ContinuousSpace})=-1,numpieces(domain(rangespace(C)))
 
 function addentries!{T,DD,CD<:Tuple{Vararg{ChebyshevDirichlet{1,1}}}}(C::ConcreteConversion{PiecewiseSpace{CD,RealBasis,DD,1},ContinuousSpace,T},A,kr::Range,::Colon)

--- a/src/Spaces/Ultraspherical/DirichletSpace.jl
+++ b/src/Spaces/Ultraspherical/DirichletSpace.jl
@@ -92,6 +92,7 @@ coefficients(v::Vector,::ChebyshevDirichlet{1,0},::Chebyshev)=idirichlettransfor
 
 ## Dirichlet Conversion operators
 
+Conversion(D::ChebyshevDirichlet,C::Chebyshev)=ConcreteConversion(D,C)
 addentries!{D,CC<:Chebyshev}(C::ConcreteConversion{ChebyshevDirichlet{1,0,D},CC},A,kr::Range,::Colon)=toeplitz_addentries!([],[1.,1.],A,kr)
 addentries!{D,CC<:Chebyshev}(C::ConcreteConversion{ChebyshevDirichlet{0,1,D},CC},A,kr::Range,::Colon)=toeplitz_addentries!([],[1.,-1.],A,kr)
 function addentries!{D,CC<:Chebyshev}(C::ConcreteConversion{ChebyshevDirichlet{1,1,D},CC},A,kr::Range,::Colon)


### PR DESCRIPTION
It's slower and more confusing that Conversion goes through a list of back ups before settling on ConcreteConversion.  Now every ConcreteConversion requires the following:

```julia
Conversion(a::MySpace,b::MyOtherSpace)=ConcreteConversion(a,b)
```
