### PR TITLE
require FastTransforms

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
 FastGaussQuadrature 0.0.3
+FastTransforms 0.0.1
 Plots 0.5
 Compat 0.7.8
 DualNumbers 0.2.1

--- a/src/ApproxFun.jl
+++ b/src/ApproxFun.jl
@@ -1,7 +1,7 @@
 __precompile__()
 
 module ApproxFun
-    using Base, Compat, Plots, FastGaussQuadrature, DualNumbers
+    using Base, Compat, Plots, FastGaussQuadrature, FastTransforms, DualNumbers
 
 
 import Base: values,getindex,setindex!,*,.*,+,.+,-,.-,==,<,<=,>,

--- a/src/Spaces/Jacobi/jacobitransform.jl
+++ b/src/Spaces/Jacobi/jacobitransform.jl
@@ -33,6 +33,9 @@ function itransform(S::Jacobi,cfs,plan::JacobiITransformPlan)
     jacobip(0:length(cfs)-1,S.a,S.b,tocanonical(S,plan.points))*cfs
 end
 
-coefficients(f::Vector,a::Jacobi,b::Chebyshev) = domain(a) == domain(b) ? cjt(f,a.a,a.b) : defaultcoefficients(f,a,b)
-coefficients(f::Vector,a::Chebyshev,b::Jacobi) = domain(a) == domain(b) ? icjt(f,b.a,b.b) : defaultcoefficients(f,a,b)
-coefficients(f::Vector,a::Jacobi,b::Jacobi) = domain(a) == domain(b) ? jjt(f,a.a,a.b,b.a,b.b) : defaultcoefficients(f,a,b)
+coefficients{T<:AbstractFloat}(f::Vector{T},a::Jacobi,b::Chebyshev) = domain(a) == domain(b) ? cjt(f,a.a,a.b) : defaultcoefficients(f,a,b)
+coefficients{T<:AbstractFloat}(f::Vector{T},a::Chebyshev,b::Jacobi) = domain(a) == domain(b) ? icjt(f,b.a,b.b) : defaultcoefficients(f,a,b)
+coefficients{T<:AbstractFloat}(f::Vector{T},a::Jacobi,b::Jacobi) = domain(a) == domain(b) ? jjt(f,a.a,a.b,b.a,b.b) : defaultcoefficients(f,a,b)
+coefficients{T<:AbstractFloat}(f::Vector{Complex{T}},a::Jacobi,b::Chebyshev) = domain(a) == domain(b) ? (p=plan_cjt(real(f),a.a,a.b);complex(p*real(f),p*imag(f))) : defaultcoefficients(f,a,b)
+coefficients{T<:AbstractFloat}(f::Vector{Complex{T}},a::Chebyshev,b::Jacobi) = domain(a) == domain(b) ? (p=plan_icjt(real(f),b.a,b.b);complex(p*real(f),p*imag(f))) : defaultcoefficients(f,a,b)
+coefficients{T<:AbstractFloat}(f::Vector{Complex{T}},a::Jacobi,b::Jacobi) = domain(a) == domain(b) ? complex(jjt(real(f),a.a,a.b,b.a,b.b),jjt(imag(f),a.a,a.b,b.a,b.b)) : defaultcoefficients(f,a,b)

--- a/src/Spaces/Jacobi/jacobitransform.jl
+++ b/src/Spaces/Jacobi/jacobitransform.jl
@@ -33,3 +33,6 @@ function itransform(S::Jacobi,cfs,plan::JacobiITransformPlan)
     jacobip(0:length(cfs)-1,S.a,S.b,tocanonical(S,plan.points))*cfs
 end
 
+coefficients(f::Vector,a::Jacobi,b::Chebyshev) = domain(a) == domain(b) ? cjt(f,a.a,a.b) : defaultcoefficients(f,a,b)
+coefficients(f::Vector,a::Chebyshev,b::Jacobi) = domain(a) == domain(b) ? icjt(f,b.a,b.b) : defaultcoefficients(f,a,b)
+coefficients(f::Vector,a::Jacobi,b::Jacobi) = domain(a) == domain(b) ? jjt(f,a.a,a.b,b.a,b.b) : defaultcoefficients(f,a,b)

--- a/test/IntegralEquationsTest.jl
+++ b/test/IntegralEquationsTest.jl
@@ -81,4 +81,4 @@ f = Fun(exp,d)
 @test rangespace(L) == Legendre(d)
 @test bandrange(V) == -1:0
 u = L\f
-@test norm(L*u-f) ≤ 10eps()
+@test norm(L*u-f) ≤ 20eps()

--- a/test/JacobiTest.jl
+++ b/test/JacobiTest.jl
@@ -107,3 +107,11 @@ D=Derivative(WeightedJacobi(.5,.5))
 g=(D*Fun(f,domainspace(D)))
 @test_approx_eq f'(0.1) g(0.1)
 
+## Test implementation of conversion between Chebyshev and Jacobi spaces using FastTransforms
+
+f = Fun(x->cospi(1000x))
+g = Fun(f,Legendre())
+h = Fun(g,Chebyshev())
+@test norm(f.coefficients-h.coefficients,Inf) < 10eps()
+h = Fun(h,Legendre())
+@test norm(g.coefficients-h.coefficients,Inf) < 100eps()


### PR DESCRIPTION
This adds requirement and capabilities of the FastTransforms package.

Currently, the constructor can’t resolve functions in the Jacobi bases past about degree 500 or so.

This PR adds alternative functionality by enabling fast conversion between Chebyshev and Jacobi coefficients:

@time Fun(Fun(x->cospi(500x)),Legendre());