### PR TITLE
copy values before TensorSpace transform

### DIFF
--- a/src/Multivariate/TensorSpace.jl
+++ b/src/Multivariate/TensorSpace.jl
@@ -229,7 +229,7 @@ end
 
 function transform(sp::TensorSpace,vals)
     m=round(Int,sqrt(length(vals)))
-    M=reshape(vals,m,m)
+    M=reshape(copy(vals),m,m)
 
     fromtensor(transform!(sp,M))
 end


### PR DESCRIPTION
Calling transform on a TensorSpace domain should not change the interpolation values.