### PR TITLE
Feat in place interlace

### DIFF
--- a/src/ApproxFun.jl
+++ b/src/ApproxFun.jl
@@ -22,7 +22,7 @@ import Base: sinpi, cospi, airy, besselh, exp,
                     expm1, log1p, lfact, sinc, cosc, erfinv, erfcinv, beta, lbeta,
                     eta, zeta, gamma,  lgamma, polygamma, invdigamma, digamma, trigamma,
                     abs, sign, log, expm1, tan, abs2, sqrt, angle, max, min, cbrt, log,
-                    atan, acos, asin, erfc
+                    atan, acos, asin, erfc, inv
 
 
 import BandedMatrices: bzeros, bandinds, bandrange, PrintShow, eachbandedindex, bandshift,
@@ -35,7 +35,9 @@ import Compat: view
 
 import FixedSizeArrays: Vec
 
-export pad!,pad,sample,chop!,complexroots,roots,svfft, reverseorientation
+export pad!, pad, chop!, sample,
+       complexroots, roots, svfft, isvfft,
+       reverseorientation
 
 ##Testing
 export bisectioninv

--- a/src/LinearAlgebra/chebyshevtransform.jl
+++ b/src/LinearAlgebra/chebyshevtransform.jl
@@ -20,7 +20,7 @@ function chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer=
         else
             ret=negateeven!(plan*x)
             ret[1]/=2
-            ret/=n
+            scale!(inv(T(n)),ret)
         end
     elseif kind == 2
         n = length(x)
@@ -29,7 +29,8 @@ function chebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer=
         else
             ret = plan*x
             ret[1] /= 2;ret[end] /= 2
-            negateeven!(ret)./(n-1)
+            negateeven!(ret)
+            scale!(inv(T(n-1)),ret)
         end
     end
 end
@@ -49,7 +50,7 @@ end
 function ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer=1)
     if kind == 1
         x[1] *=2
-        ret = plan*negateeven!(x)/2
+        ret = scale!(T(0.5),plan*negateeven!(x))
         negateeven!(x)
         x[1]/=2
         ret
@@ -64,7 +65,7 @@ function ichebyshevtransform{T<:FFTW.fftwNumber}(x::Vector{T},plan;kind::Integer
             x[1] /=2;x[end] /=2
             ret[1] *= 2;ret[end] *= 2
             negateeven!(ret)
-            ret *= .5*(n-1)
+            scale!(T(.5(n-1)),ret)
             reverse!(ret)
         end
     end
@@ -126,26 +127,4 @@ function ichebyshevtransform{T<:FFTW.fftwNumber}(X::Matrix{T};kind::Integer=1)
             flipud(fliplr(R))
         end
     end
-end
-
-
-# Helper routines
-
-
-function negateeven!(x::Vector)
-    for k =2:2:length(x)
-        x[k] = -x[k]
-    end
-    x
-end
-
-#checkerboard, same as applying negativeeven! to all rows then all columns
-function negateeven!(X::Matrix)
-    for k =2:2:size(X,1),j=1:2:size(X,2)
-        X[k,j] *= -1
-    end
-    for k =1:2:size(X,1),j=2:2:size(X,2)
-        X[k,j] *= -1
-    end
-    X
 end

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -70,19 +70,49 @@ scal!(cst::Number,v::AbstractArray) = scal!(length(v),cst,v,1)
 
 
 
-## Helper routines
-alternatingvector(n::Integer) = 2*mod([1:n],2) .- 1
+# Helper routines
 
-function alternatesign!(v::Vector)
-    n = length(v)
-    for k = 2:2:n
-        v[k] = -v[k]
+function reverseeven!(x::Vector)
+    n = length(x)
+    if iseven(n)
+        @inbounds @simd for k=2:2:n÷2
+            x[k],x[n+2-k] = x[n+2-k],x[k]
+        end
+    else
+        @inbounds @simd for k=2:2:n÷2
+            x[k],x[n+1-k] = x[n+1-k],x[k]
+        end
     end
-
-    v
+    x
 end
 
-alternatesign(v::Vector) = alternatesign!(copy(v))
+function negateeven!(x::Vector)
+    @inbounds @simd for k = 2:2:length(x)
+        x[k] *= -1
+    end
+    x
+end
+
+#checkerboard, same as applying negativeeven! to all rows then all columns
+function negateeven!(X::Matrix)
+    for j = 1:2:size(X,2)
+        @inbounds @simd for k = 2:2:size(X,1)
+            X[k,j] *= -1
+        end
+    end
+    for j = 2:2:size(X,2)
+        @inbounds @simd for k = 1:2:size(X,1)
+            X[k,j] *= -1
+        end
+    end
+    X
+end
+
+const alternatesign! = negateeven!
+
+alternatesign(v::Vector)=alternatesign!(copy(v))
+
+alternatingvector(n::Integer) = 2*mod([1:n],2) .- 1
 
 function alternatingsum(v::Vector)
     ret = zero(eltype(v))
@@ -308,7 +338,73 @@ function interlace(a::Vector,b::Vector)
 end
 
 
+### In-place O(n) interlacing
 
+function highestleader(n::Int)
+    i = 1
+    while 3i < n i *= 3 end
+    i
+end
+
+function nextindex(j::Int,n::Int)
+    j *= 2
+    m = n + 1
+    while j ≥ m
+        j -= m
+    end
+    j
+end
+
+function cycle_rotate!(v::Vector, leader::Int, it::Int, twom::Int)
+    i = nextindex(leader, twom)
+    while i != leader
+        @inbounds v[it + i-1],v[it + leader-1] = v[it + leader-1],v[it + i-1]
+        i = nextindex(i, twom)
+    end
+    v
+end
+
+function right_cyclic_shift!(v::Vector, it::Int, m::Int, n::Int)
+    itm1 = it-1
+    reverse!(v,m+it,m+n+itm1)
+    reverse!(v,m+it,2m+itm1)
+    reverse!(v,2m+it,m+n+itm1)
+    v
+end
+
+"""
+This function implements the algorithm described in:
+
+    P. Jain, "A Simple In-Place Algorithm for In-Shuffle," arXiv:0805.1598, 2008.
+"""
+function interlace!(v::Vector,offset::Int)
+    N = length(v)
+    if N < 2
+        return v
+    end
+
+    it = 1+offset
+    m = 0
+    n = 1
+
+    while m < n
+        twom = N+1-it
+        h = highestleader(twom)
+        m = h > 1 ? h÷2 : 1
+        n = twom÷2
+
+        right_cyclic_shift!(v,it,m,n)
+
+        leader = 1
+        while leader < 2m
+            cycle_rotate!(v, leader, it, 2m)
+            leader *= 3
+        end
+
+        it += 2m
+    end
+    v
+end
 
 ## svfft
 
@@ -317,27 +413,18 @@ end
 plan_svfft(x::Vector) = plan_fft(x)
 plan_isvfft(x::Vector) = plan_ifft(x)
 
-function svfft(v::Vector,plan)
-    n=length(v)
-    v=plan*v/n
+function svfft{T}(v::Vector{T},plan)
+    n = length(v)
+    v = scale!(inv(T(n)),plan*v)
     if mod(n,2) == 0
-        ind=div(n,2)
-        v=alternatesign!(v)
-        interlace(v[1:ind],
-                  flipdim(v[ind+1:end],1))
-    elseif mod(n,4)==3
-        ind=div(n+1,2)
-        interlace(alternatesign!(v[1:ind]),
-                  -flipdim(alternatesign!(v[ind+1:end]),1))
-    else #mod(length(v),4)==1
-        ind=div(n+1,2)
-        interlace(alternatesign!(v[1:ind]),
-                  flipdim(alternatesign!(v[ind+1:end]),1))
+        reverseeven!(interlace!(alternatesign!(v),1))
+    else
+        negateeven!(reverseeven!(interlace!(alternatesign!(copy(v)),1)))
     end
 end
 
 function isvfft(sv::Vector,plan)
-    n=length(sv)
+    n = length(sv)
 
     if mod(n,2) == 0
         v=alternatesign!([sv[1:2:end];flipdim(sv[2:2:end],1)])
@@ -349,11 +436,8 @@ function isvfft(sv::Vector,plan)
            alternatesign!(flipdim(sv[2:2:end],1))]
     end
 
-    plan*(n*v)
+    plan*scale!(n,v)
 end
-
-
-
 
 ## slnorm gives the norm of a slice of a matrix
 

--- a/src/LinearAlgebra/helper.jl
+++ b/src/LinearAlgebra/helper.jl
@@ -346,36 +346,38 @@ function highestleader(n::Int)
     i
 end
 
-function nextindex(j::Int,n::Int)
-    j *= 2
-    m = n + 1
-    while j ≥ m
-        j -= m
+function nextindex(i::Int,n::Int)
+    i <<= 1
+    while i > n
+        i -= n + 1
     end
-    j
+    i
 end
 
 function cycle_rotate!(v::Vector, leader::Int, it::Int, twom::Int)
     i = nextindex(leader, twom)
     while i != leader
-        @inbounds v[it + i-1],v[it + leader-1] = v[it + leader-1],v[it + i-1]
+        idx1, idx2 = it + i - 1, it + leader - 1
+        @inbounds v[idx1], v[idx2] = v[idx2], v[idx1]
         i = nextindex(i, twom)
     end
     v
 end
 
 function right_cyclic_shift!(v::Vector, it::Int, m::Int, n::Int)
-    itm1 = it-1
-    reverse!(v,m+it,m+n+itm1)
-    reverse!(v,m+it,2m+itm1)
-    reverse!(v,2m+it,m+n+itm1)
+    itpm = it + m
+    itpmm1 = itpm - 1
+    itpmpnm1 = itpmm1 + n
+    reverse!(v, itpm, itpmpnm1)
+    reverse!(v, itpm, itpmm1 + m)
+    reverse!(v, itpm + m, itpmpnm1)
     v
 end
 
 """
 This function implements the algorithm described in:
 
-    P. Jain, "A Simple In-Place Algorithm for In-Shuffle," arXiv:0805.1598, 2008.
+    P. Jain, "A simple in-place algorithm for in-shuffle," arXiv:0805.1598, 2008.
 """
 function interlace!(v::Vector,offset::Int)
     N = length(v)
@@ -383,12 +385,12 @@ function interlace!(v::Vector,offset::Int)
         return v
     end
 
-    it = 1+offset
+    it = 1 + offset
     m = 0
     n = 1
 
     while m < n
-        twom = N+1-it
+        twom = N + 1 - it
         h = highestleader(twom)
         m = h > 1 ? h÷2 : 1
         n = twom÷2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,8 @@ import ApproxFun: Infinity, ∞
 @test Infinity(true)+1 == Infinity(true)
 @test Infinity(false)+1 == Infinity(false)
 
+@test ApproxFun.interlace(collect(6:10),collect(1:5)) == ApproxFun.interlace!(collect(1:10),0)
+@test ApproxFun.interlace(collect(1:5),collect(6:10)) == ApproxFun.interlace!(collect(1:10),1)
 
 @time include("MatrixTest.jl")
 


### PR DESCRIPTION
This adds an in-place interlace method. Reduces memory requirements for Fourier and Laurent transforms. It's O(n) but marginally slower than the allocating version.

```julia
julia> using ApproxFun

julia> v = complex(rand(10_000_000),rand(10_000_000));

julia> v1 = v[1:5_000_000];

julia> v2 = v[5_000_001:end];

julia> @time for k=1:10
           ApproxFun.interlace(v1,v2);
       end
  1.303797 seconds (20 allocations: 1.490 GB, 23.83% gc time)

julia> @time for k=1:10
           ApproxFun.interlace!(v,1);
       end
  1.385689 seconds

```